### PR TITLE
upgrade prysm to v4.2.1 

### DIFF
--- a/ops/docker/Dockerfile.l1-beacon
+++ b/ops/docker/Dockerfile.l1-beacon
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 ubuntu:20.04 as chain-genesis
 RUN apt-get update && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && apt-get install build-essential curl wget git make pkg-config -y
-RUN curl -o prysmctl -fLO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.2-rc.0/prysmctl-v4.2.2-rc.0-linux-amd64
+RUN curl -o prysmctl -fLO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/prysmctl-v4.2.1-linux-amd64
 RUN chmod +x prysmctl
 COPY ops/docker/consensus /consensus
 COPY ops/docker/execution /execution
@@ -11,7 +11,7 @@ COPY --from=chain-genesis /execution /execution
 RUN geth --datadir=/execution init /execution/genesis.json
 
 
-FROM gcr.io/prysmaticlabs/prysm/beacon-chain:v4.1.1 as beacon-chain
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain:v4.2.1 as beacon-chain
 COPY --from=chain-genesis /consensus /consensus
 COPY --from=geth-genesis /execution /execution
 

--- a/ops/docker/docker-compose-4nodes.yml
+++ b/ops/docker/docker-compose-4nodes.yml
@@ -24,7 +24,7 @@ services:
     # proposed via the validators attached to the beacon node.
   beacon-chain:
       container_name: l1-beacon-chain
-#      image: gcr.io/prysmaticlabs/prysm/beacon-chain:v4.1.1
+#      image: gcr.io/prysmaticlabs/prysm/beacon-chain:v4.2.1
       image: morph-beacon-chain
       build:
         context: ../..
@@ -65,7 +65,7 @@ services:
     # The validator keys present in the beacon chain genesis state generated a few steps above.
   validator:
     container_name: l1-validator
-    image: gcr.io/prysmaticlabs/prysm/validator:v4.1.1
+    image: gcr.io/prysmaticlabs/prysm/validator:v4.2.1
     command:
       - --beacon-rpc-provider=beacon-chain:4000
       - --datadir=/consensus/validatordata


### PR DESCRIPTION
upgrade prysm to v4.2.1 so that the ethereum validator can correctly verify the kzg commitment by the updated setup