### PR TITLE
Audit N7: Fix slash

### DIFF
--- a/contracts/contracts/L1/rollup/IRollup.sol
+++ b/contracts/contracts/L1/rollup/IRollup.sol
@@ -129,12 +129,12 @@ interface IRollup {
     ///
     /// @param batchData The BatchData struct
     /// @param version The sequencer version
-    /// @param sequencerIndex The sequencers index
+    /// @param sequencers The signed sequencers
     /// @param signature The BLS signature
     function commitBatch(
         BatchData calldata batchData,
         uint256 version,
-        uint256[] memory sequencerIndex,
+        address[] memory sequencers,
         bytes memory signature
     ) external payable;
 

--- a/contracts/contracts/L1/rollup/Rollup.sol
+++ b/contracts/contracts/L1/rollup/Rollup.sol
@@ -903,7 +903,10 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
         address challenger = challenges[batchIndex].challenger;
         uint256 challengeDeposit = challenges[batchIndex].challengeDeposit;
         _transfer(challenger, challengeDeposit);
-        IL1Sequencer(l1StakingContract).slash(
+        IStaking(l1StakingContract).slash(
+            IL1Sequencer(l1SequencerContract).getSequencerAddrs(
+                IL1Sequencer(l1SequencerContract).currentVersion()
+            ),
             sequencerIndex,
             challenger,
             _minGasLimit,

--- a/contracts/contracts/L1/staking/IL1Sequencer.sol
+++ b/contracts/contracts/L1/staking/IL1Sequencer.sol
@@ -17,12 +17,12 @@ interface IL1Sequencer {
     /**
      * @notice verify BLS signature
      * @param version sequencer set version
-     * @param indexs sequencer index
+     * @param sequencers sequencers signed
      * @param signature batch signature
      */
     function verifySignature(
         uint256 version,
-        uint256[] memory indexs,
+        address[] memory sequencers,
         bytes memory signature
     ) external returns (bool);
 

--- a/contracts/contracts/L1/staking/IL1Sequencer.sol
+++ b/contracts/contracts/L1/staking/IL1Sequencer.sol
@@ -27,16 +27,6 @@ interface IL1Sequencer {
     ) external returns (bool);
 
     /**
-     * @notice challenger win, slash sequencers
-     */
-    function slash(
-        uint256[] memory sequencerIndex,
-        address challenger,
-        uint32 _minGasLimit,
-        uint256 _gasFee
-    ) external;
-
-    /**
      * @notice update sequencers version
      * @param _sequencerAddrs sequencer addresses
      * @param _sequencerBytes sequencer information bytes

--- a/contracts/contracts/L1/staking/IStaking.sol
+++ b/contracts/contracts/L1/staking/IStaking.sol
@@ -12,7 +12,6 @@ interface IStaking {
      */
     function slash(
         address[] memory sequencers,
-        uint256[] memory sequencerIndex,
         address challenger,
         uint32 _minGasLimit,
         uint256 _gasFee

--- a/contracts/contracts/L1/staking/L1Sequencer.sol
+++ b/contracts/contracts/L1/staking/L1Sequencer.sol
@@ -117,24 +117,6 @@ contract L1Sequencer is Initializable, IL1Sequencer, Sequencer, Pausable {
     }
 
     /**
-     * @notice challenger win, slash sequencers
-     */
-    function slash(
-        uint256[] memory sequencerIndex,
-        address challenger,
-        uint32 _minGasLimit,
-        uint256 _gasFee
-    ) external onlyRollupContract {
-        IStaking(stakingContract).slash(
-            sequencerAddrs[currentVersion],
-            sequencerIndex,
-            challenger,
-            _minGasLimit,
-            _gasFee
-        );
-    }
-
-    /**
      * @notice confirm sequencer ser version
      * @param version sequencer set version
      */

--- a/contracts/contracts/L1/staking/L1Sequencer.sol
+++ b/contracts/contracts/L1/staking/L1Sequencer.sol
@@ -101,17 +101,17 @@ contract L1Sequencer is Initializable, IL1Sequencer, Sequencer, Pausable {
     /**
      * @notice verify BLS signature
      * @param version sequencer set version
-     * @param indexs sequencer index
+     * @param sequencers sequencers signed
      * @param signature batch signature
      */
     function verifySignature(
         uint256 version,
-        uint256[] memory indexs,
+        address[] memory sequencers,
         bytes memory signature
     ) external onlyRollupContract whenNotPaused returns (bool) {
         confirmVersion(version);
         // TODO: verify BLS signature
-        indexs = indexs;
+        sequencers = sequencers;
         signature = signature;
         return true;
     }

--- a/contracts/contracts/L1/staking/Staking.sol
+++ b/contracts/contracts/L1/staking/Staking.sol
@@ -363,6 +363,9 @@ contract Staking is IStaking, OwnableUpgradeable {
             delete stakings[sequencer];
         }
         updateSequencers(_minGasLimit, _gasFee);
+        if (stakers.length == 0) {
+            IL1Sequencer(sequencerContract).pause();
+        }
         _transfer(challenger, valueSum);
     }
 

--- a/contracts/contracts/L1/staking/Staking.sol
+++ b/contracts/contracts/L1/staking/Staking.sol
@@ -341,7 +341,6 @@ contract Staking is IStaking, OwnableUpgradeable {
      */
     function slash(
         address[] memory sequencers,
-        uint256[] memory sequencerIndex,
         address challenger,
         uint32 _minGasLimit,
         uint256 _gasFee
@@ -352,8 +351,8 @@ contract Staking is IStaking, OwnableUpgradeable {
 
         // do slash & update sequencer set
         uint256 valueSum;
-        for (uint256 i = 0; i < sequencerIndex.length; i++) {
-            address sequencer = sequencers[sequencerIndex[i]];
+        for (uint256 i = 0; i < sequencers.length; i++) {
+            address sequencer = sequencers[i];
             valueSum += stakings[sequencer].balance;
             uint256 index = getStakerIndex(sequencer);
             for (uint256 j = index; j < stakers.length - 1; j++) {

--- a/contracts/contracts/test/L1Sequencer.t.sol
+++ b/contracts/contracts/test/L1Sequencer.t.sol
@@ -147,14 +147,18 @@ contract L1SequencerVerifyTest is L1SequencerTest {
     }
 
     function testVerifySignatureNewnest() external {
-        uint256[] memory indexs = new uint256[](0);
+        address[] memory sequencers = new address[](0);
         bytes memory signature = bytes("");
         hevm.startPrank(address(rollup));
         uint256 currentVersion = l1Sequencer.currentVersion();
         uint256 newnestVersion = l1Sequencer.newestVersion();
         for (uint256 i = currentVersion; i <= newnestVersion; i++) {
             assertTrue(
-                l1Sequencer.verifySignature(newnestVersion, indexs, signature)
+                l1Sequencer.verifySignature(
+                    newnestVersion,
+                    sequencers,
+                    signature
+                )
             );
         }
         hevm.stopPrank();

--- a/contracts/contracts/test/Rollup.t.sol
+++ b/contracts/contracts/test/Rollup.t.sol
@@ -141,7 +141,7 @@ contract RollupCommitBatchTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -292,7 +292,7 @@ contract RollupCommitBatchTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         ); // first chunk with too many txs
 
@@ -319,7 +319,7 @@ contract RollupCommitBatchTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         ); // second chunk with too many txs
         hevm.stopPrank();
@@ -354,7 +354,7 @@ contract RollupCommitBatchTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -488,7 +488,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -509,7 +509,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -530,7 +530,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -551,7 +551,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -572,7 +572,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -596,7 +596,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -624,7 +624,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -648,7 +648,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -676,7 +676,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -704,7 +704,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -728,7 +728,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -752,7 +752,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -774,7 +774,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         );
         hevm.stopPrank();
@@ -826,7 +826,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         ); // first chunk with too many txs
         hevm.stopPrank();
@@ -859,7 +859,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         ); // first chunk with too many txs
         hevm.stopPrank();
@@ -916,7 +916,6 @@ contract RollupTest is L1MessageBaseTest {
         // change to random EOA operator
         hevm.expectEmit(true, false, false, true);
         emit UpdateProver(_prover, true);
-
         assertBoolEq(rollup.isProver(_prover), false);
         rollup.addProver(_prover);
         assertBoolEq(rollup.isProver(_prover), true);
@@ -959,7 +958,7 @@ contract RollupTest is L1MessageBaseTest {
         rollup.commitBatch(
             batchData,
             sequencerVersion,
-            sequencerIndex,
+            sequencerSigned,
             signature
         ); // first chunk with too many txs
 

--- a/contracts/contracts/test/base/L1MessageBase.t.sol
+++ b/contracts/contracts/test/base/L1MessageBase.t.sol
@@ -56,7 +56,7 @@ contract L1MessageBaseTest is CommonTest {
     IRollup.BatchSignature public nilBatchSig;
     address sequencerAddr = address(uint160(beginSeq));
     uint256 public sequencerVersion;
-    uint256[] public sequencerIndex;
+    address[] public sequencerSigned;
     bytes public signature;
 
     event UpdateSequencer(address indexed account, bool status);
@@ -291,10 +291,10 @@ contract L1MessageBaseTest is CommonTest {
                 payable(address(l1MessageQueueWithGasPriceOracle))
             );
         L1MessageQueueWithGasPriceOracle l1MessageQueueWithGasPriceOracleImpl = new L1MessageQueueWithGasPriceOracle(
-                payable(_messenger), // _messenger
-                address(_rollup), // _rollup
-                address(_enforcedTxGateway) // _enforcedTxGateway
-            );
+            payable(_messenger), // _messenger
+            address(_rollup), // _rollup
+            address(_enforcedTxGateway) // _enforcedTxGateway
+        );
         assertEq(_messenger, l1MessageQueueWithGasPriceOracleImpl.messenger());
         assertEq(_rollup, l1MessageQueueWithGasPriceOracleImpl.rollup());
         assertEq(


### PR DESCRIPTION
Before BLS is implemented, the accuracy of the sequencer set uploaded by rollup cannot be guaranteed.
But the submitter is required to be in the sequencer set which version it submitted.
Therefore, if the batch is successfully challenged, only the submitter will be punished.