### PR TITLE
OZ  Audit N1 : Fix batch challenge

### DIFF
--- a/contracts/contracts/L1/staking/Staking.sol
+++ b/contracts/contracts/L1/staking/Staking.sol
@@ -27,6 +27,8 @@ contract Staking is IStaking, OwnableUpgradeable {
 
     // sequencer contract
     address public sequencerContract;
+    // rollup Contract
+    address public rollupContract;
 
     // Staking limit
     uint256 public override limit;
@@ -92,10 +94,10 @@ contract Staking is IStaking, OwnableUpgradeable {
     event WhitelistUpdated(address[] add, address[] remove);
 
     /**
-     * @notice only sequencer contract
+     * @notice only rollup contract
      */
-    modifier onlySequencerContract() {
-        require(msg.sender == sequencerContract, "only sequencer contract");
+    modifier onlyRollupContract() {
+        require(msg.sender == rollupContract, "only rollup contract");
         _;
     }
 
@@ -149,6 +151,7 @@ contract Staking is IStaking, OwnableUpgradeable {
      * @notice initializer
      * @param _admin params admin
      * @param _sequencerContract sequencer contract address
+     * @param _rollupContract rollup contract address
      * @param _sequencersSize size of sequencer set
      * @param _limit smallest staking value
      * @param _lock withdraw lock time
@@ -156,14 +159,17 @@ contract Staking is IStaking, OwnableUpgradeable {
     function initialize(
         address _admin,
         address _sequencerContract,
+        address _rollupContract,
         uint256 _sequencersSize,
         uint256 _limit,
         uint256 _lock
     ) public initializer {
+        require(_rollupContract != address(0), "invalid rollup contract");
         require(_sequencerContract != address(0), "invalid sequencer contract");
         require(_sequencersSize > 0, "sequencersSize must greater than 0");
         require(_limit > 0, "staking limit must greater than 0");
         sequencerContract = _sequencerContract;
+        rollupContract = _rollupContract;
         sequencersSize = _sequencersSize;
         limit = _limit;
         lock = _lock;
@@ -350,7 +356,7 @@ contract Staking is IStaking, OwnableUpgradeable {
         address challenger,
         uint32 _minGasLimit,
         uint256 _gasFee
-    ) external onlySequencerContract {
+    ) external onlyRollupContract {
         if (!enableSlash) {
             return;
         }

--- a/contracts/contracts/test/base/L1MessageBase.t.sol
+++ b/contracts/contracts/test/base/L1MessageBase.t.sol
@@ -191,6 +191,7 @@ contract L1MessageBaseTest is CommonTest {
                 Staking.initialize.selector,
                 address(alice),
                 address(l1SequencerProxy),
+                address(rollupProxy),
                 SEQUENCER_SIZE,
                 MIN_DEPOSIT,
                 LOCK

--- a/contracts/deploy/018-StakingInit.ts
+++ b/contracts/deploy/018-StakingInit.ts
@@ -106,6 +106,7 @@ export const StakingInit = async (
             StakingFactory.interface.encodeFunctionData('initialize', [
                 admin,
                 L1SequencerProxyAddress,
+                RollupProxyAddress,
                 sequencerSize,
                 limit,
                 hre.ethers.utils.parseEther(lock.toString()),
@@ -126,11 +127,16 @@ export const StakingInit = async (
             StakingFactory.interface,
             deployer,
         )
- 
+
         await assertContractVariable(
             contractTmp,
             'sequencerContract',
             L1SequencerProxyAddress
+        )
+        await assertContractVariable(
+            contractTmp,
+            'rollupContract',
+            RollupProxyAddress
         )
         await assertContractVariable(
             contractTmp,


### PR DESCRIPTION
Issue: When a challenge ends in the Rollup contract with the challenger winning, the staking.slash function is invoked. However, the staking.slash function includes the onlySequencerContract modifier, which should be changed to onlyRollupContract here.

Solution: Update the modifier to allow Rollup contract to call slash function.