### PR TITLE
OZ Audit N2 : Check challenge results

### DIFF
--- a/contracts/contracts/L1/rollup/Rollup.sol
+++ b/contracts/contracts/L1/rollup/Rollup.sol
@@ -120,11 +120,19 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
      */
     bool public inChallenge;
 
+    /// @dev Structure to store information about a batch challenge.
+    /// @param batchIndex The index of the challenged batch.
+    /// @param challenger The address of the challenger.
+    /// @param challengeDeposit The amount of deposit put up by the challenger.
+    /// @param startTime The timestamp when the challenge started.
+    /// @param challengeSuccess Flag indicating whether the challenge was successful.
+    /// @param finished Flag indicating whether the challenge has been resolved.
     struct BatchChallenge {
         uint64 batchIndex;
         address challenger;
         uint256 challengeDeposit;
         uint256 startTime;
+        bool challengeSuccess;
         bool finished;
     }
 
@@ -541,6 +549,7 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
             _msgSender(),
             msg.value,
             block.timestamp,
+            false,
             false
         );
         emit ChallengeState(batchIndex, _msgSender(), msg.value);
@@ -585,6 +594,8 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
         if (
             challenges[_batchIndex].startTime + PROOF_WINDOW <= block.timestamp
         ) {
+            // set status
+            challenges[_batchIndex].challengeSuccess = true;
             _challengerWin(
                 _batchIndex,
                 committedBatchStores[_batchIndex].sequencers,
@@ -694,6 +705,7 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
     function finalizeBatch(uint256 _batchIndex) public whenNotPaused {
         require(batchExist(_batchIndex), "batch not exist");
         require(!batchInChallenge(_batchIndex), "batch in challenge");
+        require(!batchChallengedSuccess(_batchIndex), "batch should be revert");
         require(
             !batchInsideChallengeWindow(_batchIndex),
             "batch in challenge window"
@@ -1143,6 +1155,14 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
         return
             challenges[batchIndex].challenger != address(0) &&
             !challenges[batchIndex].finished;
+    }
+
+    /// @dev Retrieves the success status of a batch challenge.
+    /// @param batchIndex The index of the batch to check.
+    function batchChallengedSuccess(
+        uint256 batchIndex
+    ) public view returns (bool) {
+        return challenges[batchIndex].challengeSuccess;
     }
 
     /// @dev Public function to checks whether batch exists.


### PR DESCRIPTION
Issue: During the validity check of finalizeBatch for batches, it doesn't verify whether the batch has been successfully challenged. This could result in a batch that has already been successfully challenged being finalized, leading to malicious withdrawals.

Fix: Add the attribute challengeSuccess to the BatchChallenge structure. Set its value to true when a batch is successfully challenged to indicate that the batch has been successfully challenged. Add the `batchChallengedSuccess` function for querying the result of batch challenges. Use the `batchChallengedSuccess` function during the finalizeBatch process to check if the batch has been successfully challenged.


