### PR TITLE
OZ Audit N3: Batch exist check

### DIFF
--- a/contracts/contracts/L1/rollup/Rollup.sol
+++ b/contracts/contracts/L1/rollup/Rollup.sol
@@ -1148,7 +1148,9 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
     /// @dev Public function to checks whether batch exists.
     /// @param batchIndex The index of the batch to be checked.
     function batchExist(uint256 batchIndex) public view returns (bool) {
-        return committedBatchStores[batchIndex].originTimestamp > 0;
+        return
+            committedBatchStores[batchIndex].originTimestamp > 0 &&
+            committedBatchStores[_batchIndex].batchHash != bytes32(0);
     }
 
     /// @dev Public function to checks whether the batch is in challengeWindow.

--- a/contracts/contracts/L1/rollup/Rollup.sol
+++ b/contracts/contracts/L1/rollup/Rollup.sol
@@ -1150,7 +1150,7 @@ contract Rollup is OwnableUpgradeable, PausableUpgradeable, IRollup {
     function batchExist(uint256 batchIndex) public view returns (bool) {
         return
             committedBatchStores[batchIndex].originTimestamp > 0 &&
-            committedBatchStores[_batchIndex].batchHash != bytes32(0);
+            committedBatchStores[batchIndex].batchHash != bytes32(0);
     }
 
     /// @dev Public function to checks whether the batch is in challengeWindow.


### PR DESCRIPTION
Issue: After a batch is reverted, only its batchHash is set to bytes32(0). However, the batchExist check only examines the originTimestamp, which causes the reverted batch to be considered as an existing batch. leading to malicious withdrawals.

Fix: Update the batchExist function to check filter out batches that have been reverted.