### PR TITLE
feat(gas-oracle): use ethers's provider instead of ExecutionNode

### DIFF
--- a/gas-oracle/app/src/gas_price_oracle.rs
+++ b/gas-oracle/app/src/gas_price_oracle.rs
@@ -109,8 +109,8 @@ async fn start_updater(
 async fn prepare_updater(
     config: &Config,
 ) -> Result<(BaseFeeUpdater, OverHeadUpdater), Box<dyn Error>> {
-    let l1_provider: Provider<Http> = Provider::<Http>::try_from(config.l1_rpc.clone())?;
-    let l2_provider: Provider<Http> = Provider::<Http>::try_from(config.l2_rpc.clone())?;
+    let l1_provider = Provider::<Http>::try_from(config.l1_rpc.clone())?;
+    let l2_provider = Provider::<Http>::try_from(config.l2_rpc.clone())?;
     let l2_signer = Arc::new(SignerMiddleware::new(
         l2_provider.clone(),
         Wallet::from_str(config.private_key.as_str())
@@ -118,11 +118,9 @@ async fn prepare_updater(
             .with_chain_id(l2_provider.get_chainid().await.unwrap().as_u64()),
     ));
 
-    let l2_wallet_address: Address = l2_signer.address();
-    let l2_oracle: GasPriceOracle<SignerMiddleware<Provider<Http>, _>> =
-        GasPriceOracle::new(config.l2_oracle_address, l2_signer);
-    let l1_rollup: Rollup<Provider<Http>> =
-        Rollup::new(config.l1_rollup_address, Arc::new(l1_provider.clone()));
+    let l2_wallet_address = l2_signer.address();
+    let l2_oracle = GasPriceOracle::new(config.l2_oracle_address, l2_signer);
+    let l1_rollup = Rollup::new(config.l1_rollup_address, Arc::new(l1_provider.clone()));
 
     let base_fee_updater = BaseFeeUpdater::new(
         l1_provider.clone(),
@@ -195,17 +193,18 @@ async fn handle_metrics() -> String {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore]
-async fn test() -> Result<(), Box<dyn Error>> {
-    println!("update");
-    let result = update().await;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    match result {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            println!("exec error:");
-            Err(e)
-        }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore]
+    async fn test_start_update() {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+        dotenv::dotenv().ok();
+
+        let result = update().await;
+
+        assert!(result.is_ok());
     }
 }

--- a/gas-oracle/app/src/gas_price_oracle.rs
+++ b/gas-oracle/app/src/gas_price_oracle.rs
@@ -137,7 +137,6 @@ async fn prepare_updater(
         l2_oracle.clone(),
         l1_rollup,
         config.overhead_threshold,
-        config.l1_rpc.clone(),
         config.l1_beacon_rpc.clone(),
         config.overhead_switch,
         config.max_overhead,

--- a/gas-oracle/app/src/overhead/error.rs
+++ b/gas-oracle/app/src/overhead/error.rs
@@ -7,6 +7,4 @@ pub enum OverHeadError {
     CalculateError(eyre::Error),
     #[error("{0}")]
     BeaconNodeError(eyre::Error),
-    #[error("{0}")]
-    ExecutionNodeError(eyre::Error),
 }

--- a/gas-oracle/app/src/overhead/overhead.rs
+++ b/gas-oracle/app/src/overhead/overhead.rs
@@ -326,10 +326,11 @@ impl OverHeadUpdater {
             ((rollup_gas_used * effective_gas_price).as_usize() as f64);
 
         log::info!(
-            "rollup blob tx: {:?} in block: {:?}, tx_gas_used: {:?}, blob_gas_price: {:?}, effective_gas_price: {:?}, lastest_overhead: {:?}, x: {:?}, l2_txn: {:?}, blob_fee_ratio: {}",
+            "rollup blob tx: {:?} in block: {:?}, rollup_gas_used: {:?}, sum(tx_data_gas):{:?}, blob_gas_price: {:?}, effective_gas_price: {:?}, lastest_overhead: {:?}, x: {:?}, l2_txn: {:?}, blob_fee_ratio: {}",
             tx_hash,
             block_num,
             rollup_gas_used,
+            l2_data_gas,
             blob_gas_price,
             effective_gas_price,
             overhead,
@@ -438,7 +439,6 @@ impl OverHeadUpdater {
         let tx_payload = extract_tx_payload(indexed_hashes, sidecars)?;
 
         let tx_payload_gas = data_gas_cost(&tx_payload);
-        log::debug!("sum(tx_data_gas) in blob: {}", tx_payload_gas);
 
         Ok(tx_payload_gas)
     }

--- a/gas-oracle/app/src/overhead/overhead.rs
+++ b/gas-oracle/app/src/overhead/overhead.rs
@@ -385,12 +385,12 @@ impl OverHeadUpdater {
 
         let next_block = self
             .l1_provider
-            .get_block_with_txs(BlockNumber::Number(block_num + 1))
+            .get_block(BlockNumber::Number(block_num + 1))
             .await
             .map_err(|e| OverHeadError::Error(anyhow!(format!("{:#?}", e))))?
             .ok_or_else(|| {
                 OverHeadError::Error(anyhow!(format!(
-                    "l1 get block return none, block_num: {:#?}",
+                    "l1 get next block return none, block_num: {:#?}",
                     block_num + 1
                 )))
             })?;

--- a/gas-oracle/app/src/overhead/overhead.rs
+++ b/gas-oracle/app/src/overhead/overhead.rs
@@ -284,7 +284,14 @@ impl OverHeadUpdater {
             .other
             .get_with("blobGasPrice", serde_json::from_value::<U256>)
             .unwrap_or(Ok(U256::zero()))
-            .unwrap_or_default();
+            .map_err(|e| OverHeadError::Error(anyhow!(format!("{:#?}", e))))?;
+
+        if blob_gas_price.is_zero() {
+            return Err(OverHeadError::Error(anyhow!(format!(
+                "blob tx blob_gas_price is none or 0, tx_hash = {:#?}",
+                tx_hash
+            ))));
+        }
 
         // effective_gas_price
         let effective_gas_price = blob_tx_receipt.effective_gas_price.unwrap_or_default();

--- a/gas-oracle/app/src/overhead/overhead.rs
+++ b/gas-oracle/app/src/overhead/overhead.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     metrics::ORACLE_SERVICE_METRICS,
 };
-use ethers::{abi::AbiDecode, prelude::*};
+use ethers::{abi::AbiDecode, prelude::*, utils::hex};
 use serde_json::Value;
 
 use super::blob_client::BeaconNode;
@@ -400,8 +400,10 @@ impl OverHeadUpdater {
             .ok_or_else(|| OverHeadError::Error(anyhow!("Next block not produce")))?;
 
         let indexes: Vec<u64> = indexed_hashes.iter().map(|item| item.index).collect();
-        let sidecars_rt =
-            self.beacon_node.query_sidecars(prev_beacon_root.to_string(), indexes).await?;
+        let sidecars_rt = self
+            .beacon_node
+            .query_sidecars(hex::encode_prefixed(prev_beacon_root), indexes)
+            .await?;
 
         let sidecars: &Vec<Value> = sidecars_rt["data"]
             .as_array()


### PR DESCRIPTION
1. transaction `blobVersionedHashes`
2. transactionReceipt `blobGasPrice`
3. block `parent_beacon_block_root`, `excess_blob_gas`

The fields mentioned above are all supported by ethers's Transaction, so replace ExecutionNode.
