### PR TITLE
Submitter adjust metrics

### DIFF
--- a/tx-submitter/metrics/metrics.go
+++ b/tx-submitter/metrics/metrics.go
@@ -15,8 +15,9 @@ const metricsNamespace = "submitter"
 type Metrics struct {
 	RpcErrors             prometheus.Counter
 	WalletBalance         prometheus.Gauge
-	RollupCost            prometheus.Gauge
-	FinalizeCost          prometheus.Gauge
+	RollupCost            prometheus.Counter
+	FinalizeCost          prometheus.Counter
+	L1FeeCollection       prometheus.Counter
 	IndexerBlockProcessed prometheus.Gauge
 }
 
@@ -69,12 +70,16 @@ func (m *Metrics) IncRpcErrors() {
 	m.RpcErrors.Inc()
 }
 
-func (m *Metrics) SetRollupCost(cost float64) {
-	m.RollupCost.Set(cost)
+func (m *Metrics) AddRollupCost(cost float64) {
+	m.RollupCost.Add(cost)
 }
 
-func (m *Metrics) SetFinalizeCost(cost float64) {
-	m.FinalizeCost.Set(cost)
+func (m *Metrics) AddFinalizeCost(cost float64) {
+	m.FinalizeCost.Add(cost)
+}
+
+func (m *Metrics) AddCollectedL1Fee(cost float64) {
+	m.L1FeeCollection.Add(cost)
 }
 
 func (m *Metrics) SetIndexerBlockProcessed(blockNumber uint64) {

--- a/tx-submitter/metrics/metrics.go
+++ b/tx-submitter/metrics/metrics.go
@@ -15,9 +15,12 @@ const metricsNamespace = "submitter"
 type Metrics struct {
 	RpcErrors             prometheus.Counter
 	WalletBalance         prometheus.Gauge
-	RollupCost            prometheus.Counter
-	FinalizeCost          prometheus.Counter
-	L1FeeCollection       prometheus.Counter
+	RollupCostSum         prometheus.Counter
+	FinalizeCostSum       prometheus.Counter
+	RollupCost            prometheus.Gauge
+	FinalizeCost          prometheus.Gauge
+	L1FeeCollectionSum    prometheus.Counter
+	L1FeeCollection       prometheus.Gauge
 	IndexerBlockProcessed prometheus.Gauge
 }
 
@@ -34,6 +37,16 @@ func NewMetrics() *Metrics {
 			Help:      "Wallet balance",
 			Namespace: metricsNamespace,
 		}),
+		RollupCostSum: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "submitter_rollup_cost_sum",
+			Help:      "Rollup cost",
+			Namespace: metricsNamespace,
+		}),
+		FinalizeCostSum: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "submitter_finalize_cost_sum",
+			Help:      "Finalize cost",
+			Namespace: metricsNamespace,
+		}),
 		RollupCost: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "submitter_rollup_cost",
 			Help:      "Rollup cost",
@@ -44,6 +57,17 @@ func NewMetrics() *Metrics {
 			Help:      "Finalize cost",
 			Namespace: metricsNamespace,
 		}),
+		L1FeeCollection: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "submitter_l1_fee_collection",
+			Help:      "L1 fee collection",
+			Namespace: metricsNamespace,
+		}),
+		L1FeeCollectionSum: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "submitter_l1_fee_collection_sum",
+			Help:      "L1 fee collection",
+			Namespace: metricsNamespace,
+		}),
+
 		IndexerBlockProcessed: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "submitter_indexer_block_processed",
 			Help:      "Indexer block processed",
@@ -70,16 +94,19 @@ func (m *Metrics) IncRpcErrors() {
 	m.RpcErrors.Inc()
 }
 
-func (m *Metrics) AddRollupCost(cost float64) {
-	m.RollupCost.Add(cost)
+func (m *Metrics) SetRollupCost(cost float64) {
+	m.RollupCostSum.Add(cost)
+	m.RollupCost.Set(cost)
 }
 
-func (m *Metrics) AddFinalizeCost(cost float64) {
-	m.FinalizeCost.Add(cost)
+func (m *Metrics) SetFinalizeCost(cost float64) {
+	m.FinalizeCostSum.Add(cost)
+	m.RollupCost.Set(cost)
 }
 
-func (m *Metrics) AddCollectedL1Fee(cost float64) {
-	m.L1FeeCollection.Add(cost)
+func (m *Metrics) SetCollectedL1Fee(cost float64) {
+	m.L1FeeCollectionSum.Add(cost)
+	m.L1FeeCollection.Set(cost)
 }
 
 func (m *Metrics) SetIndexerBlockProcessed(blockNumber uint64) {

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -323,11 +323,11 @@ func (r *Rollup) ProcessTx() error {
 					log.Warn("fee is zero", "hash", rtx.Hash().Hex())
 				}
 				if method == "commitBatch" {
-					r.metrics.AddRollupCost(fee)
+					r.metrics.SetRollupCost(fee)
 					index := utils.ParseParentBatchIndex(rtx.Data()) + 1
 					batch, ok := r.batchCache[index]
 					if ok {
-						r.metrics.AddCollectedL1Fee(ToEtherFloat((*big.Int)(batch.CollectedL1Fee)))
+						r.metrics.SetCollectedL1Fee(ToEtherFloat((*big.Int)(batch.CollectedL1Fee)))
 						// remove batch from cache
 						delete(r.batchCache, index)
 					} else {
@@ -337,7 +337,7 @@ func (r *Rollup) ProcessTx() error {
 					}
 
 				} else if method == "finalizeBatch" {
-					r.metrics.AddFinalizeCost(fee)
+					r.metrics.SetFinalizeCost(fee)
 				}
 			}
 

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -66,6 +66,9 @@ type Rollup struct {
 	cfg utils.Config
 	// signer
 	signer types.Signer
+
+	// batchcache
+	batchCache map[uint64]*eth.RPCRollupBatch
 }
 
 func NewRollup(
@@ -320,9 +323,21 @@ func (r *Rollup) ProcessTx() error {
 					log.Warn("fee is zero", "hash", rtx.Hash().Hex())
 				}
 				if method == "commitBatch" {
-					r.metrics.SetRollupCost(fee)
+					r.metrics.AddRollupCost(fee)
+					index := utils.ParseParentBatchIndex(rtx.Data()) + 1
+					batch, ok := r.batchCache[index]
+					if ok {
+						r.metrics.AddCollectedL1Fee(ToEtherFloat((*big.Int)(batch.CollectedL1Fee)))
+						// remove batch from cache
+						delete(r.batchCache, index)
+					} else {
+						log.Warn("batch not found in batchCache while set collect fee metrics",
+							"index", index,
+						)
+					}
+
 				} else if method == "finalizeBatch" {
-					r.metrics.SetFinalizeCost(fee)
+					r.metrics.AddFinalizeCost(fee)
 				}
 			}
 
@@ -607,7 +622,9 @@ func (r *Rollup) rollup() error {
 		return nil
 	}
 
-	blockContexts := batch.BlockContexts
+	// set batch cache
+	// it shoud be removed after the batch is committed
+	r.batchCache[batchIndex] = batch
 
 	signature, err := r.buildSignatureInput(batch)
 	if err != nil {
@@ -616,7 +633,7 @@ func (r *Rollup) rollup() error {
 	rollupBatch := bindings.IRollupBatchDataInput{
 		Version:                uint8(batch.Version),
 		ParentBatchHeader:      batch.ParentBatchHeader,
-		BlockContexts:          blockContexts,
+		BlockContexts:          batch.BlockContexts,
 		SkippedL1MessageBitmap: batch.SkippedL1MessageBitmap,
 		PrevStateRoot:          batch.PrevStateRoot,
 		PostStateRoot:          batch.PostStateRoot,

--- a/tx-submitter/services/utils.go
+++ b/tx-submitter/services/utils.go
@@ -61,7 +61,12 @@ func calcFee(receipt *types.Receipt) float64 {
 	}
 
 	fee := new(big.Int).Add(calldatafee, blobfee)
-	feeEther := new(big.Rat).SetFrac(fee, big.NewInt(params.Ether))
-	fEtherFee, _ := feeEther.Float64()
-	return fEtherFee
+	return ToEtherFloat(fee)
+}
+
+func ToEtherFloat(weiAmt *big.Int) float64 {
+	etherAmt := new(big.Rat).SetFrac(weiAmt, big.NewInt(params.Ether))
+	fEtherAmt, _ := etherAmt.Float64()
+	return fEtherAmt
+
 }


### PR DESCRIPTION
- Add couter metrics for finalize, rollup and l1CollectFee to track Rollup cost & batch income
- Add batchCache for use in other functions of the rollup service.