### PR TITLE
Check previous state root

### DIFF
--- a/contracts/contracts/l1/rollup/Rollup.sol
+++ b/contracts/contracts/l1/rollup/Rollup.sol
@@ -97,6 +97,9 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
     /// @notice prove remaining
     uint256 public proveRemaining;
 
+    /// @notice committedStateRoots
+    mapping(uint256 batchIndex => bytes32 stateRoot) public committedStateRoots;
+
     /**********************
      * Function Modifiers *
      **********************/
@@ -192,6 +195,7 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
         committedBatches[_batchIndex] = _batchHash;
         batchDataStore[_batchIndex] = BatchData(block.timestamp, block.timestamp, 0, 0);
 
+        committedStateRoots[_batchIndex] = _postStateRoot;
         finalizedStateRoots[_batchIndex] = _postStateRoot;
         lastCommittedBatchIndex = _batchIndex;
         lastFinalizedBatchIndex = _batchIndex;
@@ -226,9 +230,10 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
         // the variable `batchPtr` will be reused later for the current batch
         (uint256 _batchPtr, bytes32 _parentBatchHash) = _loadBatchHeader(batchDataInput.parentBatchHeader);
         uint256 _batchIndex = BatchHeaderCodecV0.getBatchIndex(_batchPtr);
-        require(committedBatches[_batchIndex] == _parentBatchHash, "incorrect parent batch hash");
         require(committedBatches[_batchIndex + 1] == bytes32(0), "batch already committed");
         require(_batchIndex == lastCommittedBatchIndex, "incorrect batch index");
+        require(committedBatches[_batchIndex] == _parentBatchHash, "incorrect parent batch hash");
+        require(committedStateRoots[_batchIndex] == batchDataInput.prevStateRoot, "incorrect previous state root");
 
         uint256 _totalL1MessagesPoppedOverall = BatchHeaderCodecV0.getTotalL1MessagePopped(_batchPtr);
         // compute the data hash for batch
@@ -278,8 +283,9 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
             BatchHeaderCodecV0.storeSkippedBitmap(_batchPtr, batchDataInput.skippedL1MessageBitmap);
             BatchHeaderCodecV0.storeBlobVersionedHash(_batchPtr, _blobVersionedHash);
             committedBatches[_batchIndex] = BatchHeaderCodecV0.computeBatchHash(_batchPtr, _headerLength);
+            committedStateRoots[_batchIndex] = batchDataInput.postStateRoot;
             uint256 proveRemainingTime = 0;
-            if (inChallenge){
+            if (inChallenge) {
                 // Make the batch finalize time longer than the time required for the current challenge
                 proveRemainingTime = proofWindow + challenges[batchChallenged].startTime - block.timestamp;
             }
@@ -500,7 +506,6 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
         (uint256 memPtr, bytes32 _batchHash) = _loadBatchHeader(_batchHeader);
         uint256 _batchIndex = BatchHeaderCodecV0.getBatchIndex(memPtr);
         require(committedBatches[_batchIndex] == _batchHash, "incorrect batch hash");
-
         require(batchExist(_batchIndex), "batch not exist");
         require(!batchInChallenge(_batchIndex), "batch in challenge");
         require(!batchChallengedSuccess(_batchIndex), "batch should be revert");
@@ -530,6 +535,7 @@ contract Rollup is IRollup, OwnableUpgradeable, PausableUpgradeable {
         );
 
         delete batchDataStore[_batchIndex - 1];
+        delete committedStateRoots[_batchIndex - 1];
         delete challenges[_batchIndex - 1];
 
         emit FinalizeBatch(


### PR DESCRIPTION
Check previous state root on `SubmitBatch`.

Because the prevStateRoot is not validated until a batch is finalized, a committed batch with a malicious prevStateRoot can be used to both (a) win challenges against honest challengers and (b) halt the chain since it will be approved but be unable to be finalized.