### PR TITLE
Hotfix(tx-submitter): correct failed index handling and add tests

### DIFF
--- a/tx-submitter/services/pendingtx.go
+++ b/tx-submitter/services/pendingtx.go
@@ -174,7 +174,7 @@ func (pt *PendingTxs) SetFailedStatus(index uint64) {
 	defer pt.mu.Unlock()
 
 	// failed index must be less than pindex
-	if pt.failedIndex != nil || index >= pt.pindex {
+	if pt.failedIndex != nil || index > pt.pindex {
 		return
 	}
 

--- a/tx-submitter/services/pendingtx_test.go
+++ b/tx-submitter/services/pendingtx_test.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFailedStatus(t *testing.T) {
+	// index 2 failed -> set failed index 2 success
+	pt := NewPendingTxs(nil, nil, nil)
+	pt.SetPindex(2)
+	require.Nil(t, pt.failedIndex)
+	pt.SetFailedStatus(2)
+	require.NotNil(t, pt.failedIndex)
+	require.EqualValues(t, 2, *pt.failedIndex)
+
+	// failed index =2
+	// new failed index = 3
+	// set failed index failed
+	pt = NewPendingTxs(nil, nil, nil)
+	failedIndex := uint64(2)
+	pt.failedIndex = &failedIndex
+	pt.SetFailedStatus(3)
+	require.EqualValues(t, 2, *pt.failedIndex)
+
+	// set failed index without pindex -> failed
+	pt = NewPendingTxs(nil, nil, nil)
+	pt.SetFailedStatus(2)
+	require.Nil(t, pt.failedIndex)
+}

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -638,8 +638,12 @@ func (r *Rollup) rollup() error {
 			batchIndex = cindex + 1
 		}
 	}
-
-	log.Info("batch info", "last_commit_batch", batchIndex-1, "batch_will_get", batchIndex)
+	log.Info("batch index info",
+		"last_commited_batch_index", cindex,
+		"batch_index_will_get", batchIndex,
+		"pending_index", r.pendingTxs.pindex,
+		"failed_index", r.pendingTxs.failedIndex,
+	)
 	if r.pendingTxs.ExistedIndex(batchIndex) {
 		log.Info("batch index already committed", "index", batchIndex)
 		return nil


### PR DESCRIPTION
- Fix condition in SetFailedStatus to allow setting failed index equal to pindex
- Add unit tests for SetFailedStatus to cover different scenarios
- Update rollup function to log more detailed batch index information