### PR TITLE
feat(event): replace file storage with leveldb for event info

### DIFF
--- a/tx-submitter/event/storage.go
+++ b/tx-submitter/event/storage.go
@@ -3,10 +3,11 @@ package event
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+
 	"morph-l2/tx-submitter/db"
 	"morph-l2/tx-submitter/params"
 	"morph-l2/tx-submitter/utils"
-	"sync"
 )
 
 type IEventStorage interface {

--- a/tx-submitter/event/storage.go
+++ b/tx-submitter/event/storage.go
@@ -3,7 +3,9 @@ package event
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"morph-l2/tx-submitter/db"
+	"morph-l2/tx-submitter/params"
+	"morph-l2/tx-submitter/utils"
 	"sync"
 )
 
@@ -12,10 +14,6 @@ type IEventStorage interface {
 	Load() error
 }
 
-var (
-	defaultFilename = "event_info.json"
-)
-
 type EventInfo struct {
 	BlockTime      uint64 `json:"block_time"`      // event emit time
 	BlockProcessed uint64 `json:"block_processed"` // block processed
@@ -23,51 +21,55 @@ type EventInfo struct {
 
 type EventInfoStorage struct {
 	EventInfo
-	Filename string `json:"filename"` // filename
-	lock     sync.Mutex
+	db *db.Db
+	mu sync.Mutex
 }
 
-func NewEventInfoStorage(filename string) *EventInfoStorage {
-	if filename == "" {
-		filename = defaultFilename
-	}
+func NewEventInfoStorage(db *db.Db) *EventInfoStorage {
 	return &EventInfoStorage{
-		Filename: filename,
+		db: db,
 	}
 }
 
 func (e *EventInfoStorage) Store() error {
 
 	// Convert struct to JSON string
-	jsonData, err := json.Marshal(e)
+	jsonData, err := json.Marshal(e.EventInfo)
 	if err != nil {
 		return fmt.Errorf("failed to convert struct to JSON: %w", err)
 	}
 
-	e.lock.Lock()
-	defer e.lock.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	// Write JSON data to file
-	err = os.WriteFile(e.Filename, jsonData, 0600)
+	err = e.db.PutString(params.EventInfoKey, string(jsonData))
 	if err != nil {
-		return fmt.Errorf("failed to write to file: %w", err)
+		return fmt.Errorf("failed to write to db: err=%w, data=%v", err, jsonData)
 	}
-
 	return nil
 }
 func (e *EventInfoStorage) Load() error {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	jsonData, err := os.ReadFile(e.Filename)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	evnetInfo, err := e.db.GetString(params.EventInfoKey)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if utils.ErrStringMatch(err, db.ErrKeyNotFound) {
 			e.EventInfo = EventInfo{}
+			jsonData, err := json.Marshal(e.EventInfo)
+			if err != nil {
+				return fmt.Errorf("failed to marshal json: %w", err)
+			}
+			err = e.db.PutString(params.EventInfoKey, string(jsonData))
+			if err != nil {
+				return fmt.Errorf("failed to init eventinfo to db: %w", err)
+			}
 			return nil
 		}
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to load eventinfo from db: %w", err)
 	}
 
 	// parse json data to struct
-	err = json.Unmarshal(jsonData, e)
+	err = json.Unmarshal([]byte(evnetInfo), &e.EventInfo)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}

--- a/tx-submitter/event/storage_test.go
+++ b/tx-submitter/event/storage_test.go
@@ -1,15 +1,18 @@
 package event
 
 import (
+	"morph-l2/tx-submitter/db"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestEventInfoStorage(t *testing.T) {
-	filename := "hello.json"
-	storage := NewEventInfoStorage(filename)
-	err := storage.Load()
+
+	db, err := db.New("./testleveldb")
+	require.NoError(t, err)
+	storage := NewEventInfoStorage(db)
+	err = storage.Load()
 	require.NoError(t, err)
 
 	storage.BlockTime = 100
@@ -17,7 +20,7 @@ func TestEventInfoStorage(t *testing.T) {
 	err = storage.Store()
 	require.NoError(t, err)
 
-	storage2 := NewEventInfoStorage(filename)
+	storage2 := NewEventInfoStorage(db)
 	err = storage2.Load()
 	require.NoError(t, err)
 	require.Equal(t, storage.BlockTime, storage2.BlockTime)

--- a/tx-submitter/params/leveldb_keys.go
+++ b/tx-submitter/params/leveldb_keys.go
@@ -1,0 +1,5 @@
+package params
+
+const (
+	EventInfoKey = "event_info"
+)

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -75,8 +75,9 @@ type Rollup struct {
 	// collectedL1FeeSum
 	collectedL1FeeSum float64
 	// batchcache
-	batchCache *BatchCache
-	bm         *l1checker.BlockMonitor
+	batchCache       *BatchCache
+	bm               *l1checker.BlockMonitor
+	eventInfoStorage *event.EventInfoStorage
 }
 
 func NewRollup(
@@ -96,27 +97,29 @@ func NewRollup(
 	rotator *Rotator,
 	ldb *db.Db,
 	bm *l1checker.BlockMonitor,
+	eventInfoStorage *event.EventInfoStorage,
 ) *Rollup {
 
 	return &Rollup{
-		ctx:             ctx,
-		metrics:         metrics,
-		l1RpcClient:     l1RpcClient,
-		L1Client:        l1,
-		Rollup:          rollup,
-		Staking:         staking,
-		L2Clients:       l2Clients,
-		privKey:         priKey,
-		chainId:         chainId,
-		rollupAddr:      rollupAddr,
-		abi:             abi,
-		rotator:         rotator,
-		cfg:             cfg,
-		signer:          types.LatestSignerForChainID(chainId),
-		externalRsaPriv: rsaPriv,
-		batchCache:      NewBatchCache(),
-		ldb:             ldb,
-		bm:              bm,
+		ctx:              ctx,
+		metrics:          metrics,
+		l1RpcClient:      l1RpcClient,
+		L1Client:         l1,
+		Rollup:           rollup,
+		Staking:          staking,
+		L2Clients:        l2Clients,
+		privKey:          priKey,
+		chainId:          chainId,
+		rollupAddr:       rollupAddr,
+		abi:              abi,
+		rotator:          rotator,
+		cfg:              cfg,
+		signer:           types.LatestSignerForChainID(chainId),
+		externalRsaPriv:  rsaPriv,
+		batchCache:       NewBatchCache(),
+		ldb:              ldb,
+		bm:               bm,
+		eventInfoStorage: eventInfoStorage,
 	}
 }
 
@@ -561,24 +564,27 @@ func (r *Rollup) rollup() error {
 			return fmt.Errorf("rollup: get current submitter err, %w", err)
 		}
 
-		storage := event.NewEventInfoStorage(r.rotator.indexer.GetStorePath())
-		err = storage.Load()
+		err = r.eventInfoStorage.Load()
 		if err != nil {
 			return fmt.Errorf("failed to load storage in rollup: %w", err)
 		}
+		log.Info("indexer info",
+			"block_processed", r.eventInfoStorage.EventInfo.BlockProcessed,
+			"event_latest_emit_time", r.eventInfoStorage.EventInfo.BlockTime,
+		)
 		// get current blocknumber
 		blockNumber, err := r.L1Client.BlockNumber(context.Background())
 		if err != nil {
 			return fmt.Errorf("failed to get block number in rollup: %w", err)
 		}
 		// set metrics
-		r.metrics.SetIndexerBlockProcessed(storage.EventInfo.BlockProcessed)
+		r.metrics.SetIndexerBlockProcessed(r.eventInfoStorage.EventInfo.BlockProcessed)
 		// check if indexed block number is too old
-		if blockNumber > storage.EventInfo.BlockProcessed+100 {
+		if blockNumber > r.eventInfoStorage.EventInfo.BlockProcessed+100 {
 			log.Info("indexed block number is too old, wait indexer to catch up",
 				"module", r.GetModuleName(),
 				"block_number", blockNumber,
-				"processed_block", storage.EventInfo.BlockProcessed)
+				"processed_block", r.eventInfoStorage.EventInfo.BlockProcessed)
 			return nil
 		}
 

--- a/tx-submitter/services/rotator.go
+++ b/tx-submitter/services/rotator.go
@@ -56,7 +56,7 @@ func (r *Rotator) UpdateState(clients []iface.L2Client, l1Staking iface.IL1Staki
 		return fmt.Errorf("GetCurrentSubmitter: failed to get sequencer set update time: %w", err)
 	}
 
-	storage := event.NewEventInfoStorage(r.indexer.GetStorePath())
+	storage := r.indexer.GetStorage()
 	err = storage.Load()
 	if err != nil {
 		log.Error("failed to load storage", "err", err)
@@ -92,6 +92,16 @@ func (r *Rotator) UpdateState(clients []iface.L2Client, l1Staking iface.IL1Staki
 	}
 	submitterSet := utils.IntersectionOfAddresses(r.GetSequencerSet(), stakers)
 	r.SetSubmitterSet(submitterSet)
+	// rotator info
+	log.Info(
+		"rotator state updated",
+		"epoch", r.epoch,
+		"start", r.startTime,
+		"epoch_update_time", epochUpdateTime,
+		"seq_update_time", sequcerUpdateTime,
+		"indexed_latest_block", storage.BlockProcessed,
+		"indexed_event_emit_time", storage.BlockTime,
+	)
 
 	return nil
 }


### PR DESCRIPTION
- Remove EventInfoStorage file operations
- Use Db from tx-submitter/db for event info storage
- Update EventIndexer to use EventInfoStorage interface
- Modify Rollup and Rotator to use new EventInfoStorage implementation
- Add GetString and PutString methods to db.Db
- Create EventInfoKey constant in params