### PR TITLE
feat(tx-submitter): add tip fee bump functionality

### DIFF
--- a/tx-submitter/entry.go
+++ b/tx-submitter/entry.go
@@ -69,6 +69,10 @@ func Main() func(ctx *cli.Context) error {
 			"rough_estimate_per_l1_msg", cfg.RollupTxGasPerL1Msg,
 			"log_level", cfg.LogLevel,
 			"leveldb_pathname", cfg.LeveldbPathName,
+			"min_tip", cfg.MinTip,
+			"max_tip", cfg.MaxTip,
+			"max_base", cfg.MaxBaseFee,
+			"tip_bump", cfg.TipFeeBump,
 		)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -223,19 +223,19 @@ var (
 	MaxTipFlag = cli.Uint64Flag{
 		Name:   "max_tip",
 		Usage:  "The maximum tip for a transaction",
-		Value:  10000000000, //10gwei
+		Value:  10e9, //10gwei
 		EnvVar: prefixEnvVar("MAX_TIP"),
 	}
 	MinTipFlag = cli.Uint64Flag{
 		Name:   "min_tip",
 		Usage:  "The minimum tip for a transaction",
-		Value:  500000000, //0.5gwei
+		Value:  5e8, //0.5gwei
 		EnvVar: prefixEnvVar("MIN_TIP"),
 	}
 	MaxBaseFeeFlag = cli.Uint64Flag{
 		Name:   "max_base_fee",
 		Usage:  "The maximum base fee for a transaction",
-		Value:  100000000000, //100gwei
+		Value:  100e9, //100gwei
 		EnvVar: prefixEnvVar("MAX_BASE_FEE"),
 	}
 
@@ -364,6 +364,9 @@ var optionalFlags = []cli.Flag{
 	L2SequencerAddressFlag,
 	L2GovAddressFlag,
 	TipFeeBumpFlag,
+	MaxTipFlag,
+	MinTipFlag,
+	MaxBaseFeeFlag,
 	MaxTxsInPendingPoolFlag,
 
 	// external sign

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -214,17 +214,29 @@ var (
 		Value:  "StakingEventStore.json",
 	}
 
-	CalldataFeeBumpFlag = cli.Uint64Flag{
-		Name:   "call_data_fee_bump",
-		Usage:  "The fee bump for call data",
-		Value:  100, //fee = x * origin_fee/100
-		EnvVar: prefixEnvVar("CALL_DATA_FEE_BUMP"),
-	}
 	TipFeeBumpFlag = cli.Uint64Flag{
 		Name:   "TIP_FEE_BUMP",
 		Usage:  "The fee bump for tip",
 		Value:  100, //bumpTip = tip * TipFeeBump/100
 		EnvVar: prefixEnvVar("TIP_FEE_BUMP"),
+	}
+	MaxTipFlag = cli.Uint64Flag{
+		Name:   "max_tip",
+		Usage:  "The maximum tip for a transaction",
+		Value:  10e9, //10gwei
+		EnvVar: prefixEnvVar("MAX_TIP"),
+	}
+	MinTipFlag = cli.Uint64Flag{
+		Name:   "min_tip",
+		Usage:  "The minimum tip for a transaction",
+		Value:  5e8, //0.5gwei
+		EnvVar: prefixEnvVar("MIN_TIP"),
+	}
+	MaxBaseFeeFlag = cli.Uint64Flag{
+		Name:   "max_base_fee",
+		Usage:  "The maximum base fee for a transaction",
+		Value:  100e9, //100gwei
+		EnvVar: prefixEnvVar("MAX_BASE_FEE"),
 	}
 
 	MaxTxsInPendingPoolFlag = cli.Uint64Flag{
@@ -351,7 +363,6 @@ var optionalFlags = []cli.Flag{
 	PrivateKeyFlag,
 	L2SequencerAddressFlag,
 	L2GovAddressFlag,
-	CalldataFeeBumpFlag,
 	TipFeeBumpFlag,
 	MaxTxsInPendingPoolFlag,
 

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -220,6 +220,12 @@ var (
 		Value:  100, //fee = x * origin_fee/100
 		EnvVar: prefixEnvVar("CALL_DATA_FEE_BUMP"),
 	}
+	TipFeeBumpFlag = cli.Uint64Flag{
+		Name:   "TIP_FEE_BUMP",
+		Usage:  "The fee bump for tip",
+		Value:  100, //bumpTip = tip * TipFeeBump/100
+		EnvVar: prefixEnvVar("TIP_FEE_BUMP"),
+	}
 
 	MaxTxsInPendingPoolFlag = cli.Uint64Flag{
 		Name:   "max_txs_in_pending_pool",
@@ -346,6 +352,7 @@ var optionalFlags = []cli.Flag{
 	L2SequencerAddressFlag,
 	L2GovAddressFlag,
 	CalldataFeeBumpFlag,
+	TipFeeBumpFlag,
 	MaxTxsInPendingPoolFlag,
 
 	// external sign

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -223,19 +223,19 @@ var (
 	MaxTipFlag = cli.Uint64Flag{
 		Name:   "max_tip",
 		Usage:  "The maximum tip for a transaction",
-		Value:  10e9, //10gwei
+		Value:  10000000000, //10gwei
 		EnvVar: prefixEnvVar("MAX_TIP"),
 	}
 	MinTipFlag = cli.Uint64Flag{
 		Name:   "min_tip",
 		Usage:  "The minimum tip for a transaction",
-		Value:  5e8, //0.5gwei
+		Value:  500000000, //0.5gwei
 		EnvVar: prefixEnvVar("MIN_TIP"),
 	}
 	MaxBaseFeeFlag = cli.Uint64Flag{
 		Name:   "max_base_fee",
 		Usage:  "The maximum base fee for a transaction",
-		Value:  100e9, //100gwei
+		Value:  100000000000, //100gwei
 		EnvVar: prefixEnvVar("MAX_BASE_FEE"),
 	}
 

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -217,7 +217,7 @@ var (
 	TipFeeBumpFlag = cli.Uint64Flag{
 		Name:   "TIP_FEE_BUMP",
 		Usage:  "The fee bump for tip",
-		Value:  100, //bumpTip = tip * TipFeeBump/100
+		Value:  120, //bumpTip = tip * TipFeeBump/100
 		EnvVar: prefixEnvVar("TIP_FEE_BUMP"),
 	}
 	MaxTipFlag = cli.Uint64Flag{

--- a/tx-submitter/mock/l1mock.go
+++ b/tx-submitter/mock/l1mock.go
@@ -1,0 +1,87 @@
+package mock
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/morph-l2/go-ethereum"
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/types"
+)
+
+type L1ClientWrapper struct {
+	Block  *types.Block
+	TipCap *big.Int
+}
+
+func NewL1ClientWrapper() *L1ClientWrapper {
+	return &L1ClientWrapper{}
+}
+
+func (c *L1ClientWrapper) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return nil, nil
+}
+
+func (c *L1ClientWrapper) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func (c *L1ClientWrapper) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	return nil, false, nil
+}
+
+func (c *L1ClientWrapper) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
+
+func (c *L1ClientWrapper) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return nil, nil
+}
+
+func (c *L1ClientWrapper) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return c.Block.Header(), nil
+}
+
+func (c *L1ClientWrapper) BlockNumber(ctx context.Context) (uint64, error) {
+	return c.Block.NumberU64(), nil
+}
+
+func (c *L1ClientWrapper) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	ch <- c.Block.Header()
+	return nil, nil
+}
+
+func (c *L1ClientWrapper) SetBlock(block *types.Block) {
+	c.Block = block
+}
+func (c *L1ClientWrapper) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *L1ClientWrapper) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (c *L1ClientWrapper) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+	return nil, nil
+}
+func (c *L1ClientWrapper) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	return 0, nil
+}
+func (c *L1ClientWrapper) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+func (c *L1ClientWrapper) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return c.TipCap, nil
+}
+func (c *L1ClientWrapper) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+	return 0, nil
+}
+func (c *L1ClientWrapper) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return nil
+}
+func (c *L1ClientWrapper) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	return nil, nil
+}
+func (c *L1ClientWrapper) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, nil
+}

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -855,6 +855,7 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, error) {
 		return nil, nil, nil, err
 	}
 	if head.BaseFee != nil {
+		log.Info("market fee info", "feecap", head.BaseFee)
 		if r.cfg.MaxBaseFee > 0 && head.BaseFee.Cmp(big.NewInt(int64(r.cfg.MaxBaseFee))) > 0 {
 			return nil, nil, nil, fmt.Errorf("base fee is too high, base fee %v exceeds max %v", head.BaseFee, r.cfg.MaxBaseFee)
 		}
@@ -864,6 +865,8 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, error) {
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	log.Info("market fee info", "tip", tip)
+
 	if r.cfg.TipFeeBump > 0 {
 		tip = new(big.Int).Mul(tip, big.NewInt(int64(r.cfg.TipFeeBump)))
 		tip = new(big.Int).Div(tip, big.NewInt(100))
@@ -887,6 +890,12 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, error) {
 	if head.ExcessBlobGas != nil {
 		blobFee = eip4844.CalcBlobFee(*head.ExcessBlobGas)
 	}
+
+	log.Info("fee info after bump",
+		"tip", tip,
+		"feecap", gasFeeCap,
+		"blobfee", blobFee,
+	)
 
 	return tip, gasFeeCap, blobFee, nil
 }

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -1104,7 +1104,7 @@ func (r *Rollup) SendTx(tx *types.Transaction) error {
 		return errors.New("nil tx")
 	}
 	// l1 health check
-	if !r.bm.IsGrowth() {
+	if r.bm != nil && !r.bm.IsGrowth() {
 		return fmt.Errorf("block not growth in %d blocks time", r.cfg.BlockNotIncreasedThreshold)
 	}
 
@@ -1115,7 +1115,9 @@ func (r *Rollup) SendTx(tx *types.Transaction) error {
 
 	// after send tx
 	// add to pending txs
-	r.pendingTxs.Add(tx)
+	if r.pendingTxs != nil {
+		r.pendingTxs.Add(tx)
+	}
 
 	return nil
 

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -871,10 +871,6 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, error) {
 	if r.cfg.MaxTip > 0 && tip.Cmp(big.NewInt(int64(r.cfg.MaxTip))) > 0 {
 		return nil, nil, nil, fmt.Errorf("tip is too high, tip %v exceeds max %v", tip, r.cfg.MaxTip)
 	}
-	if r.cfg.MinTip > 0 && tip.Cmp(big.NewInt(int64(r.cfg.MinTip))) < 0 {
-		log.Info("tip is too low", "tip", tip, "min_tip", r.cfg.MinTip)
-		tip = big.NewInt(int64(r.cfg.MinTip))
-	}
 
 	var gasFeeCap *big.Int
 	if head.BaseFee != nil {
@@ -1191,6 +1187,11 @@ func (r *Rollup) ReSubmitTx(resend bool, tx *types.Transaction) (*types.Transact
 			if bumpedBlobFeeCap.Cmp(blobFeeCap) > 0 {
 				blobFeeCap = bumpedBlobFeeCap
 			}
+		}
+
+		if r.cfg.MinTip > 0 && tip.Cmp(big.NewInt(int64(r.cfg.MinTip))) < 0 {
+			log.Info("replace tip is too low, update tip to min tip ", "tip", tip, "min_tip", r.cfg.MinTip)
+			tip = big.NewInt(int64(r.cfg.MinTip))
 		}
 	}
 

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -853,6 +853,10 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, error) {
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if r.cfg.TipFeeBump > 0 {
+		tip = new(big.Int).Mul(tip, big.NewInt(int64(r.cfg.TipFeeBump)))
+		tip = new(big.Int).Div(tip, big.NewInt(100))
+	}
 	head, err := r.L1Client.HeaderByNumber(context.Background(), nil)
 	if err != nil {
 		return nil, nil, nil, err

--- a/tx-submitter/utils/config.go
+++ b/tx-submitter/utils/config.go
@@ -82,10 +82,11 @@ type Config struct {
 
 	// journal file path
 	JournalFilePath string
-	// calldata fee bump
-	CalldataFeeBump uint64
 	// tip bump
 	TipFeeBump uint64
+	MaxTip     uint64
+	MinTip     uint64
+	MaxBaseFee uint64
 	//max txs in pendingpool
 	MaxTxsInPendingPool uint64
 
@@ -154,8 +155,10 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		GasLimitBuffer: ctx.GlobalUint64(flags.GasLimitBuffer.Name),
 
 		JournalFilePath:     ctx.GlobalString(flags.JournalFlag.Name),
-		CalldataFeeBump:     ctx.GlobalUint64(flags.CalldataFeeBumpFlag.Name),
 		TipFeeBump:          ctx.GlobalUint64(flags.TipFeeBumpFlag.Name),
+		MaxTip:              ctx.GlobalUint64(flags.MaxTipFlag.Name),
+		MinTip:              ctx.GlobalUint64(flags.MinTipFlag.Name),
+		MaxBaseFee:          ctx.GlobalUint64(flags.MaxBaseFeeFlag.Name),
 		MaxTxsInPendingPool: ctx.GlobalUint64(flags.MaxTxsInPendingPoolFlag.Name),
 
 		// external sign

--- a/tx-submitter/utils/config.go
+++ b/tx-submitter/utils/config.go
@@ -84,6 +84,8 @@ type Config struct {
 	JournalFilePath string
 	// calldata fee bump
 	CalldataFeeBump uint64
+	// tip bump
+	TipFeeBump uint64
 	//max txs in pendingpool
 	MaxTxsInPendingPool uint64
 
@@ -151,9 +153,9 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 
 		GasLimitBuffer: ctx.GlobalUint64(flags.GasLimitBuffer.Name),
 
-		JournalFilePath: ctx.GlobalString(flags.JournalFlag.Name),
-		// calldata fee bump
+		JournalFilePath:     ctx.GlobalString(flags.JournalFlag.Name),
 		CalldataFeeBump:     ctx.GlobalUint64(flags.CalldataFeeBumpFlag.Name),
+		TipFeeBump:          ctx.GlobalUint64(flags.TipFeeBumpFlag.Name),
 		MaxTxsInPendingPool: ctx.GlobalUint64(flags.MaxTxsInPendingPoolFlag.Name),
 
 		// external sign


### PR DESCRIPTION
Enhancements to tx-submitter Fee Handling, Logging, and Testing

Feature Improvements:

- Added detailed logging for market fee information, including base fee and tip, as well as configurations for new fee-related parameters.
Introduced logging updates after tip bump calculations and blob fee adjustments.
Testing Enhancements:

- Added a mock L1 client for testing and enhanced Rollup service tests to cover more scenarios.
Implemented new test cases for GetGasTipAndCap and ReSubmitTx functionalities, improving error handling and edge case coverage.
Refactor:

- Updated tip fee handling by increasing the default TipFeeBump from 100% to 120%.
Simplified tip calculation by moving minimum tip enforcement logic from GetGasTipAndCap to ReSubmitTx.
Fee Configuration Changes:

- Removed CalldataFeeBumpFlag and introduced MaxTipFlag, MinTipFlag, and MaxBaseFeeFlag.
Enhanced fee enforcement logic to include maximum base fee, maximum tip, and minimum tip, with updated logic in GetGasTipAndCap.