### PR TITLE
fix: Add return value checks for ERC20 transfers in L2Staking

### DIFF
--- a/contracts/contracts/l2/staking/L2Staking.sol
+++ b/contracts/contracts/l2/staking/L2Staking.sol
@@ -604,7 +604,7 @@ contract L2Staking is IL2Staking, Staking, OwnableUpgradeable, ReentrancyGuardUp
     /// @notice transfer morph token
     function _transfer(address _to, uint256 _amount) internal {
         uint256 balanceBefore = IMorphToken(MORPH_TOKEN_CONTRACT).balanceOf(_to);
-        IMorphToken(MORPH_TOKEN_CONTRACT).transfer(_to, _amount);
+        require(IMorphToken(MORPH_TOKEN_CONTRACT).transfer(_to, _amount), "transfer failed");
         uint256 balanceAfter = IMorphToken(MORPH_TOKEN_CONTRACT).balanceOf(_to);
         require(_amount > 0 && balanceAfter - balanceBefore == _amount, "morph token transfer failed");
     }
@@ -612,7 +612,7 @@ contract L2Staking is IL2Staking, Staking, OwnableUpgradeable, ReentrancyGuardUp
     /// @notice transfer morph token from
     function _transferFrom(address _from, address _to, uint256 _amount) internal {
         uint256 balanceBefore = IMorphToken(MORPH_TOKEN_CONTRACT).balanceOf(_to);
-        IMorphToken(MORPH_TOKEN_CONTRACT).transferFrom(_from, _to, _amount);
+        require(IMorphToken(MORPH_TOKEN_CONTRACT).transferFrom(_from, _to, _amount), "transferFrom failed");
         uint256 balanceAfter = IMorphToken(MORPH_TOKEN_CONTRACT).balanceOf(_to);
         require(_amount > 0 && balanceAfter - balanceBefore == _amount, "morph token transfer failed");
     }


### PR DESCRIPTION
I've found a potential security vulnerability in the L2Staking contract's _transfer and _transferFrom functions:
The issue is in both transfer functions where they check the balance difference after the transfer. While they verify that the balance increased by the expected amount, they don't check if the initial transfer operation was successful.

This commit adds explicit checks for the return values of ERC20 transfer and transferFrom operations in the L2Staking contract. While the contract already verified balance changes, it didn't check if the initial transfer succeeded.

- Add require statement to check transfer() return value
- Add require statement to check transferFrom() return value
- Improve error messages to be more specific
- Maintain existing balance difference checks as additional safety

This change follows ERC20 best practices and prevents potential issues with tokens that don't revert on failed transfers.