### PR TITLE
Fix typos in `rollup.go`, `executor.go`, `staking_upgrade.ts`, and `L2Staking.t.sol`

### DIFF
--- a/contracts/contracts/test/L2Staking.t.sol
+++ b/contracts/contracts/test/L2Staking.t.sol
@@ -1239,7 +1239,7 @@ contract L2StakingTest is L2StakingBaseTest {
         l2Staking.claimReward(secondStaker, 2);
         uint256 balanceAfter = morphToken.balanceOf(bob);
 
-        // sequncer size = 3
+        // sequencer size = 3
         // proposal same blocks in epoch 2
         // commission = 1
         // alice delegate 5 ether morph token
@@ -2097,7 +2097,7 @@ contract L2StakingTest is L2StakingBaseTest {
         l2Staking.claimReward(firstStaker, 0);
         uint256 balanceAfter = morphToken.balanceOf(alice);
 
-        // sequncer size = 3
+        // sequencer size = 3
         // proposal same blocks in every epoch
         // commission = 1
         // alice delegate 5 ether morph token in epoch 0 - 1, undeletegate at epoch 1. valid reward epoch is 0, 1

--- a/contracts/tasks/staking_upgrade.ts
+++ b/contracts/tasks/staking_upgrade.ts
@@ -434,7 +434,7 @@ task("l1staking-deploy-init")
             console.log("BLOCK_NUMBER: %s", blockNumber)
             const err = await storage(newPath, ImplStorageName.L1StakingStorageName, contract.address.toLocaleLowerCase(), blockNumber || 0)
             if (err != '') {
-                console.log(`deploy L1Staking implemention failed ${err}`)
+                console.log(`deploy L1Staking implementation failed ${err}`)
                 return err
             }
         }

--- a/node/core/executor.go
+++ b/node/core/executor.go
@@ -146,7 +146,7 @@ var _ l2node.L2Node = (*Executor)(nil)
 
 func (e *Executor) RequestBlockData(height int64) (txs [][]byte, blockMeta []byte, collectedL1Msgs bool, err error) {
 	if e.l1MsgReader == nil {
-		err = fmt.Errorf("RequestBlockData is not alllowed to be called")
+		err = fmt.Errorf("RequestBlockData is not allowed to be called")
 		return
 	}
 	e.logger.Info("RequestBlockData request", "height", height)
@@ -208,7 +208,7 @@ func (e *Executor) RequestBlockData(height int64) (txs [][]byte, blockMeta []byt
 
 func (e *Executor) CheckBlockData(txs [][]byte, metaData []byte) (valid bool, err error) {
 	if e.l1MsgReader == nil {
-		return false, fmt.Errorf("RequestBlockData is not alllowed to be called")
+		return false, fmt.Errorf("RequestBlockData is not allowed to be called")
 	}
 	if len(metaData) == 0 {
 		e.logger.Error("metaData cannot be nil")

--- a/oracle/oracle/rollup.go
+++ b/oracle/oracle/rollup.go
@@ -140,7 +140,7 @@ func (o *Oracle) recordRollupEpoch() error {
 		}
 		epochs, err := o.generateRollupEpoch(epochIndex.Int64(), rollupEpoch.EndTime.Int64(), epochTime.Int64(), updateTime, int64(endBlock), int64(header.Time), math.MaxInt64, sets)
 		if err != nil {
-			return fmt.Errorf("gernerate rollup epoch info error:%v", err)
+			return fmt.Errorf("generate rollup epoch info error:%v", err)
 		}
 		rollupEpochInfos = append(rollupEpochInfos, epochs...)
 	}


### PR DESCRIPTION
1. **`L2Staking.t.sol`**:
   - Corrected "sequncer" to "sequencer" in comments describing test scenarios.

2. **`staking_upgrade.ts`**:
   - Fixed "implemention" to "implementation" in a log message.

3. **`executor.go`**:
   - Corrected "alllowed" to "allowed" in error messages.

4. **`rollup.go`**:
   - Fixed "gernerate" to "generate" in an error message.