### PR TITLE
Fix spelling error

### DIFF
--- a/contracts/tasks/overflow_test.ts
+++ b/contracts/tasks/overflow_test.ts
@@ -170,8 +170,8 @@ task("upgradeRollup")
 
         const upgradeTx = await RollupProxyWithSigner.upgradeTo(rollupNewImpl.address)
         console.log("upgradeTx hash: ", upgradeTx.hash)
-        const recipt = await upgradeTx.wait()
-        console.log("recipt status: ", recipt.status)
+        const receipt = await upgradeTx.wait()
+        console.log("receipt status: ", receipt.status)
 
         console.log("after upgrade the impl contract is :", await RollupProxy.callStatic.implementation({
             from: ethers.constants.AddressZero,

--- a/oracle/oracle/oracle.go
+++ b/oracle/oracle/oracle.go
@@ -63,7 +63,7 @@ func Main() func(ctx *cli.Context) error {
 			log.Info("metrics server enabled", "host", cfg.MetricsHostname, "port", cfg.MetricsPort)
 		}
 		<-(chan struct{})(nil)
-		log.Info("staking oracle stoped")
+		log.Info("staking oracle stopped")
 		return nil
 	}
 }

--- a/oracle/oracle/reward.go
+++ b/oracle/oracle/reward.go
@@ -310,7 +310,7 @@ func (o *Oracle) setStartBlock() {
 			if errors.Is(err, ErrRewardNotStart) {
 				log.Info(err.Error())
 			} else {
-				log.Error("query reward start falied", "error", err)
+				log.Error("query reward start failed", "error", err)
 			}
 			time.Sleep(defaultSleepTime)
 			continue


### PR DESCRIPTION
- Corrected **recipt → receipt** in `overflow_test.ts`.  
- Fixed **stoped → stopped** in `oracle.go`.  
- Corrected **falied → failed** in `reward.go`.  
