### PR TITLE
Refine Documentation and Code Comments for Improved Clarity  

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -9,7 +9,7 @@ This package contains the smart contracts that compose the on-chain component.
 | Name                                                                               | Proxy Type                                                              | Description                                                                                      |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | [`L1CrossDomainMessenger`](../../specs/messengers.md)                              | [`ResolvedDelegateProxy`](./contracts/legacy/ResolvedDelegateProxy.sol) | High-level interface for sending messages to and receiving messages from M                       |
-| [`L1StandardBridge`](../../specs/bridges.md)                                       | [`L1ChugSplashProxy`](./contracts/legacy/L1ChugSplashProxy.sol)         | Standardized system for transfering ERC20 tokens to/from Mo r p h                                |
+| [`L1StandardBridge`](../../specs/bridges.md)                                       | [`L1ChugSplashProxy`](./contracts/legacy/L1ChugSplashProxy.sol)         | Standardized system for transferring ERC20 tokens to/from Mo r p h                                |
 | [`Rollup`](../../specs/proposals.md#rollup.sol)                                    | [`Proxy`](./contracts/universal/Proxy.sol)                              | Stores commitments to the state of Morph which can be used by contracts on L1 to access L2 state |
 | [`MorphPortal`](../../specs/deposits.md#deposit-contract)                          | [`Proxy`](./contracts/universal/Proxy.sol)                              | Low-level message passing interface                                                              |
 | [`MorphMintableERC20Factory`](../../specs/predeploys.md#morphmintableerc20factory) | [`Proxy`](./contracts/universal/Proxy.sol)                              | Deploys standard `MorphMintableERC20` tokens that are compatible with either `StandardBridge`    |
@@ -79,7 +79,7 @@ yarn test
 
 You must have [Echidna](https://github.com/crytic/echidna) installed.
 
-Contracts targetted for Echidna testing are located in `./contracts/echidna`.
+Contracts targeted for Echidna testing are located in `./contracts/echidna`.
 Each target contract is tested with a separate yarn command, for example:
 
 ```shell

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -683,7 +683,7 @@ func (r *Rollup) rollup() error {
 	}
 
 	// set batch cache
-	// it shoud be removed after the batch is committed
+	// it should be removed after the batch is committed
 	r.batchCache.Set(batchIndex, batch)
 
 	signature, err := r.buildSignatureInput(batch)
@@ -1345,7 +1345,7 @@ func (r *Rollup) InitFeeMetricsSum() error {
 				return fmt.Errorf("put rollupFeeSum to leveldb failed, key: %s, %w", rollupSumKey, err)
 			}
 		} else {
-			return fmt.Errorf("get data from leveldb faild, key: %s, %w", rollupSumKey, err)
+			return fmt.Errorf("get data from leveldb failed, key: %s, %w", rollupSumKey, err)
 		}
 	}
 	log.Info("rollupFeeSum: %f", rollupFeeSum)
@@ -1358,7 +1358,7 @@ func (r *Rollup) InitFeeMetricsSum() error {
 				return fmt.Errorf("put finalizeFeeSum to leveldb failed, key: %s, %w", finalizeSumKey, err)
 			}
 		} else {
-			return fmt.Errorf("get data from leveldb faild, key: %s, %w", finalizeSumKey, err)
+			return fmt.Errorf("get data from leveldb failed, key: %s, %w", finalizeSumKey, err)
 		}
 	}
 	log.Info("finalizeFeeSum: %f", finalizeFeeSum)
@@ -1371,7 +1371,7 @@ func (r *Rollup) InitFeeMetricsSum() error {
 				return fmt.Errorf("put collectedL1FeeSum to leveldb failed, key: %s, %w", collectedL1FeeSumKey, err)
 			}
 		} else {
-			return fmt.Errorf("get data from leveldb faild, key: %s, %w", collectedL1FeeSumKey, err)
+			return fmt.Errorf("get data from leveldb failed, key: %s, %w", collectedL1FeeSumKey, err)
 		}
 	}
 	r.collectedL1FeeSum = collectedL1FeeSum


### PR DESCRIPTION
### Changes  
- **`README.md`**:  
  - Fixed spelling of "transferring" and "targeted" for better accuracy.  

- **`rollup.go`**:  
  - `"shoud"` → `"should"`  
  - `"faild"` → `"failed"` (multiple instances)  
