### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/node/core/sequencers.go
+++ b/node/core/sequencers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/morph-l2/go-ethereum/common"
@@ -13,7 +14,6 @@ import (
 	"github.com/tendermint/tendermint/blssignatures"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	"golang.org/x/exp/slices"
 )
 
 const tmKeySize = ed25519.PubKeySize


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.