### PR TITLE
refactor: update signer to use LatestSignerForChainID

### DIFF
--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -116,7 +116,7 @@ func NewRollup(
 		abi:              abi,
 		rotator:          rotator,
 		cfg:              cfg,
-		signer:           ethtypes.NewLondonSigner(chainId),
+		signer:           ethtypes.LatestSignerForChainID(chainId),
 		externalRsaPriv:  rsaPriv,
 		batchCache:       types.NewBatchCache(batchFetcher),
 		ldb:              ldb,


### PR DESCRIPTION
Replaced the LondonSigner with LatestSignerForChainID in the Rollup service initialization to ensure compatibility with the latest Ethereum chain standards.