### PR TITLE
When not found blob return error

### DIFF
--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -374,11 +374,10 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 			}
 
 			d.logger.Info("Blob matching results", "matched", matchedCount, "expected", len(blobHashes))
-			if matchedCount > 0 {
-				batch.Sidecar = blobTxSidecar
-			} else {
+			if matchedCount == 0 {
 				return nil, fmt.Errorf("no matching versionedHash was found")
 			}
+			batch.Sidecar = blobTxSidecar
 		} else {
 			return nil, fmt.Errorf("not matched blob,txHash:%v,blockNumber:%v", txHash, blockNumber)
 		}

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -376,6 +376,8 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 			d.logger.Info("Blob matching results", "matched", matchedCount, "expected", len(blobHashes))
 			if matchedCount > 0 {
 				batch.Sidecar = blobTxSidecar
+			} else {
+				return nil, fmt.Errorf("no matching versionedHash was found")
 			}
 		} else {
 			return nil, fmt.Errorf("not matched blob,txHash:%v,blockNumber:%v", txHash, blockNumber)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when no matching versioned hash is found for transactions containing blobs, ensuring users receive clear feedback in such cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->