### PR TITLE
feat: remove L2Gov contract dependency

### DIFF
--- a/tx-submitter/entry.go
+++ b/tx-submitter/entry.go
@@ -50,7 +50,6 @@ func Main() func(ctx *cli.Context) error {
 			"l2_rpcs", cfg.L2EthRpcs,
 			"rollup_addr", cfg.RollupAddress,
 			"l2_sequencer_addr", cfg.L2SequencerAddress,
-			"l2_gov_addr", cfg.L2GovAddress,
 			"l1_staking_addr", cfg.L1StakingAddress,
 			"fee_limit", cfg.TxFeeLimit,
 			"finalize_enable", cfg.Finalize,
@@ -199,7 +198,7 @@ func Main() func(ctx *cli.Context) error {
 		}
 		eventIndexer := event.NewEventIndexer(l1Client, new(big.Int).SetUint64(cfg.L1StakingDeployedBlockNumber), filter, cfg.EventIndexStep, eventInfoStorage)
 		// new rotator
-		rotator := services.NewRotator(common.HexToAddress(cfg.L2SequencerAddress), common.HexToAddress(cfg.L2GovAddress), eventIndexer)
+		rotator := services.NewRotator(common.HexToAddress(cfg.L2SequencerAddress), eventIndexer, cfg.RollupEpoch)
 		// start rorator event indexer
 		rotator.StartEventIndexer()
 

--- a/tx-submitter/flags/flags.go
+++ b/tx-submitter/flags/flags.go
@@ -90,13 +90,6 @@ var (
 		EnvVar:   prefixEnvVar("L2_SEQUENCER_ADDRESS"),
 		Value:    predeploys.Sequencer,
 	}
-	L2GovAddressFlag = cli.StringFlag{
-		Name:     "l2_gov_address",
-		Usage:    "Address of the gov contract",
-		Required: false,
-		EnvVar:   prefixEnvVar("L2_GOV_ADDRESS"),
-		Value:    predeploys.Gov,
-	}
 
 	/* Optional Flags */
 	LogLevelFlag = cli.StringFlag{
@@ -324,6 +317,14 @@ var (
 		Value:  5,
 		EnvVar: prefixEnvVar("BLOCK_NOT_INCREASED_THRESHOLD"),
 	}
+
+	RollupEpochFlag = cli.Uint64Flag{
+		Name:     "rollup_epoch",
+		Usage:    "The rollup epoch",
+		Value:    3600, // seconds
+		EnvVar:   prefixEnvVar("ROLLUP_EPOCH"),
+		Required: true,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -337,6 +338,7 @@ var requiredFlags = []cli.Flag{
 	TxFeeLimitFlag,
 	L1StakingAddressFlag,
 	L1StakingDeployedBlocknumFlag,
+	RollupEpochFlag,
 }
 
 var optionalFlags = []cli.Flag{
@@ -362,7 +364,6 @@ var optionalFlags = []cli.Flag{
 
 	PrivateKeyFlag,
 	L2SequencerAddressFlag,
-	L2GovAddressFlag,
 	TipFeeBumpFlag,
 	MaxTipFlag,
 	MinTipFlag,

--- a/tx-submitter/iface/rollup.go
+++ b/tx-submitter/iface/rollup.go
@@ -25,9 +25,6 @@ type IL2Sequencer interface {
 	GetSequencerSet2() ([]common.Address, error)
 }
 
-type IL2Gov interface {
-	RollupEpoch(opts *bind.CallOpts) (*big.Int, error)
-}
 type IL1Staking interface {
 	IsStaker(opts *bind.CallOpts, addr common.Address) (bool, error)
 	GetStakersBitmap(opts *bind.CallOpts, _stakers []common.Address) (*big.Int, error)

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -1380,29 +1380,6 @@ func QuerySequencerSet(addr common.Address, clients []iface.L2Client) ([]common.
 	return nil, fmt.Errorf("no sequencer set found after querying all clients")
 }
 
-// query epoch from gov contract on l2
-func GetEpoch(addr common.Address, clients []iface.L2Client) (*big.Int, error) {
-	if len(clients) < 1 {
-		return nil, fmt.Errorf("no client to query epoch")
-	}
-	for _, client := range clients {
-		// l2 gov
-		l2Gov, err := bindings.NewGov(addr, client)
-		if err != nil {
-			log.Warn("failed to connect to gov", "error", err)
-			continue
-		}
-		// get epoch
-		epoch, err := l2Gov.RollupEpoch(nil)
-		if err != nil {
-			log.Warn("failed to get epoch", "error", err)
-			continue
-		}
-		return epoch, nil
-	}
-	return nil, fmt.Errorf("no epoch found after querying all clients")
-}
-
 // query sequencer set update time from sequencer contract on l2
 func GetSequencerSetUpdateTime(addr common.Address, clients []iface.L2Client) (*big.Int, error) {
 
@@ -1425,31 +1402,6 @@ func GetSequencerSetUpdateTime(addr common.Address, clients []iface.L2Client) (*
 		return updateTime, nil
 	}
 	return nil, fmt.Errorf("no sequencer set update time found after querying all clients")
-}
-
-// query epoch update time from gov contract on l2
-func GetEpochUpdateTime(addr common.Address, clients []iface.L2Client) (*big.Int, error) {
-	if len(clients) < 1 {
-		return nil, fmt.Errorf("no client to query epoch update time")
-	}
-	for _, client := range clients {
-		// l2 gov
-		l2Gov, err := bindings.NewGov(addr, client)
-		if err != nil {
-			log.Warn("failed to connect to gov", "error", err)
-			continue
-		}
-		// get epoch update time
-		updateTime, err := l2Gov.RollupEpochUpdateTime(nil)
-		if err != nil {
-			log.Warn("failed to get epoch update time", "error", err)
-			continue
-		}
-		return updateTime, nil
-
-	}
-	return nil, fmt.Errorf("no epoch update time found after querying all clients")
-
 }
 
 func UpdateGasLimit(tx *ethtypes.Transaction) (*ethtypes.Transaction, error) {

--- a/tx-submitter/services/rollup_handle_test.go
+++ b/tx-submitter/services/rollup_handle_test.go
@@ -63,7 +63,7 @@ func setupTestRollup(t *testing.T) (*Rollup, *mock.L1ClientWrapper, *mock.L2Clie
 	)
 
 	// Create mock rotator
-	rotator := NewRotator(common.Address{}, common.Address{}, indexer)
+	rotator := NewRotator(common.Address{}, indexer, 3600)
 
 	// Create mock L1Staking
 	l1Staking := mock.NewMockL1Staking()

--- a/tx-submitter/utils/config.go
+++ b/tx-submitter/utils/config.go
@@ -48,7 +48,6 @@ type Config struct {
 	Finalize bool
 	// L2 contract
 	L2SequencerAddress string
-	L2GovAddress       string
 
 	// metrics
 	MetricsServerEnable bool
@@ -110,6 +109,8 @@ type Config struct {
 	// leveldb path name
 	LeveldbPathName            string
 	BlockNotIncreasedThreshold int64
+
+	RollupEpoch uint64
 }
 
 // NewConfig parses the DriverConfig from the provided flags or environment variables.
@@ -130,7 +131,6 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		RollupAddress:    ctx.GlobalString(flags.RollupAddressFlag.Name),
 		// L2 contract
 		L2SequencerAddress: ctx.GlobalString(flags.L2SequencerAddressFlag.Name),
-		L2GovAddress:       ctx.GlobalString(flags.L2GovAddressFlag.Name),
 		// metrics
 		MetricsServerEnable: ctx.GlobalBool(flags.MetricsServerEnable.Name),
 		MetricsHostname:     ctx.GlobalString(flags.MetricsHostname.Name),
@@ -183,6 +183,8 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		LeveldbPathName: ctx.GlobalString(flags.LeveldbPathNameFlag.Name),
 		// BlockNotIncreasedThreshold
 		BlockNotIncreasedThreshold: ctx.GlobalInt64(flags.BlockNotIncreasedThreshold.Name),
+
+		RollupEpoch: ctx.GlobalUint64(flags.RollupEpochFlag.Name),
 	}
 
 	return cfg, nil


### PR DESCRIPTION
- Replaces L2Gov contract-based epoch retrieval with a configurable RollupEpoch parameter.
- Removes associated flags, methods, and logic tied to L2Gov contract.