### PR TITLE
Add hoodi gas-oracle build

### DIFF
--- a/MakefileEks.mk
+++ b/MakefileEks.mk
@@ -107,6 +107,20 @@ build-bk-prod-morph-prod-testnet-to-morph-gas-price-oracle-holesky:
 start-bk-prod-morph-prod-testnet-to-morph-gas-price-oracle-holesky:
 	/data/secret-manager-wrapper ./app
 
+# gas-oracle
+# hoodi
+build-bk-prod-morph-prod-testnet-to-morph-gas-price-oracle-hoodi:
+	if [ ! -d dist ]; then mkdir -p dist; fi
+	cd $(PWD)/gas-oracle/app && cargo build --release
+	cp gas-oracle/app/target/release/app dist/
+	aws s3 cp s3://morph-0582-morph-technical-department-testnet-data/testnet/hoodi/morph-setup/secret-manager-wrapper.tar.gz ./
+	tar -xvzf secret-manager-wrapper.tar.gz
+
+
+start-bk-prod-morph-prod-testnet-to-morph-gas-price-oracle-hoodi:
+	/data/secret-manager-wrapper ./app
+
+
 # prover
 # testnet
 build-bk-prod-morph-prod-testnet-to-morph-prover-holesky:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new build and start commands to automate preparing and launching the gas price oracle in the Morph prod testnet environment.
  * Build command assembles required artifacts if missing; start command runs the service with necessary dependencies.
  * Improves deployment reliability and reduces manual steps.
  * No user-facing behavior changes or public interface updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->