### PR TITLE
specified gitmodules via tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "go-ethereum"]
 path = go-ethereum
 url = https://github.com/morph-l2/go-ethereum.git
-branch = release/2.0.x

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ################## update dependencies ####################
-
+ETHEREUM_SUBMODULE_COMMIT_OR_TAG := morph-v2.0.8
 ETHEREUM_TARGET_VERSION := morph-v2.0.8
 TENDERMINT_TARGET_VERSION := v0.3.2
 
@@ -39,7 +39,13 @@ update:
 
 submodules:
 	git submodule update --init
-	git submodule update --remote 
+	@if [ -d "go-ethereum" ]; then \
+		echo "Updating go-ethereum submodule to tag $(ETHEREUM_SUBMODULE_COMMIT_OR_TAG)..."; \
+		cd go-ethereum && \
+		git fetch --tags && \
+		git checkout $(ETHEREUM_SUBMODULE_COMMIT_OR_TAG) && \
+		cd ..; \
+	fi
 .PHONY: submodules
 
 ################## bindings ####################


### PR DESCRIPTION
Configure gitmodule via specified tag, instead of branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git submodule configuration to remove explicit branch specification, allowing submodules to track default or configured branches.
  * Modified submodule update process to use conditional tag-based checkout instead of blanket remote updates, enabling more precise version pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->