### PR TITLE
fix(node): Fix validator set hash mismatch at height 18409547

### DIFF
--- a/node/core/config.go
+++ b/node/core/config.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	MainnetUpgradeBatchTime uint64 = 2000
-	HoleskyUpgradeBatchTime uint64 = 350000
+	MainnetUpgradeBatchTime      uint64 = 0
+	MainnetBlsKeyCheckForkHeight uint64 = 18409547
 )
 
 type Config struct {
@@ -35,6 +35,7 @@ type Config struct {
 	L2StakingAddress              common.Address  `json:"l2staking_address"`
 	MaxL1MessageNumPerBlock       uint64          `json:"max_l1_message_num_per_block"`
 	UpgradeBatchTime              uint64          `json:"upgrade_batch_time"`
+	BlsKeyCheckForkHeight         uint64          `json:"bls_key_check_fork_height"`
 	DevSequencer                  bool            `json:"dev_sequencer"`
 	Logger                        tmlog.Logger    `json:"logger"`
 }
@@ -157,12 +158,12 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		c.DevSequencer = ctx.GlobalBool(flags.DevSequencer.Name)
 	}
 
-	// setup batch upgrade index
+	// setup batch upgrade index and fork heights
 	switch {
 	case ctx.GlobalIsSet(flags.MainnetFlag.Name):
 		c.UpgradeBatchTime = MainnetUpgradeBatchTime
-	case ctx.GlobalIsSet(flags.HoleskyFlag.Name):
-		c.UpgradeBatchTime = HoleskyUpgradeBatchTime
+		c.BlsKeyCheckForkHeight = MainnetBlsKeyCheckForkHeight
+		logger.Info("set UpgradeBatchTime: ", c.UpgradeBatchTime, "BlsKeyCheckForkHeight: ", c.BlsKeyCheckForkHeight)
 	case ctx.GlobalIsSet(flags.UpgradeBatchTime.Name):
 		c.UpgradeBatchTime = ctx.GlobalUint64(flags.UpgradeBatchTime.Name)
 		logger.Info("set UpgradeBatchTime: ", ctx.GlobalUint64(flags.UpgradeBatchTime.Name))

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -230,10 +230,6 @@ var (
 		Name:  "mainnet",
 		Usage: "Morph mainnet",
 	}
-	HoleskyFlag = cli.BoolFlag{
-		Name:  "holesky",
-		Usage: "Morph Holesky",
-	}
 
 	DerivationConfirmations = cli.Int64Flag{
 		Name:   "derivation.confirmations",
@@ -345,7 +341,6 @@ var Flags = []cli.Flag{
 	// batch rules
 	UpgradeBatchTime,
 	MainnetFlag,
-	HoleskyFlag,
 
 	// logger
 	LogLevel,


### PR DESCRIPTION
## Problem

At block height 18409547, a transaction added a new sequencer with an invalid blsKey. This caused all validator nodes to halt because the original code returned an error when blsKey decoding failed.

After deploying a hotfix (using `continue` instead of `return nil, err`), nodes successfully resumed block production. However, a critical inconsistency emerged:

- **Old nodes (restarted after the hotfix)**: When replaying block 18409547, geth had already executed the block, so `DeliverBlock` called `getParamsAndValsAtHeight()` which returned **5 sequencers** (including the invalid one) because it didn't validate blsKey.
- **New nodes (syncing from scratch)**: When executing block 18409547 normally, `DeliverBlock` called `updateSequencerSet()` → `sequencerSetUpdates()` which returned **4 sequencers** (skipping the invalid one).

This caused different `next_validators_hash` values:
- Old nodes: `65C2A11E5A28F185EC039D2B9F7A0AAFFC6B577BC596BD46176F8B203F51D9FF`
- New nodes: `D3CF5BD31E9E1776EA7E656E3E10B2DE3CE8AD413B205F286E816404A43D7071`

New nodes fail to sync past height 18409548 due to validator hash verification failure.

## Root Cause

Inconsistent blsKey validation between two code paths:
1. `sequencerSetUpdates()` - validates blsKey, skips invalid sequencers
2. `getParamsAndValsAtHeight()` - did NOT validate blsKey, included all sequencers

## Solution

1. Add `blsKeyCheckForkHeight = 18409547` constant
2. Add height parameter to `sequencerSetUpdates()` and `updateSequencerSet()`
3. For heights **<= 18409547**: Include sequencers even if blsKey validation fails (historical compatibility)
4. For heights **> 18409547**: Skip sequencers with invalid blsKey (correct behavior)

This ensures:
- New nodes calculate the same validator set hash as historical blocks
- Future blocks enforce proper blsKey validation

## Block Data Reference

| Height | validators_hash | next_validators_hash |
|--------|----------------|---------------------|
| 18409547 | D3CF... | D3CF... |
| 18409548 | D3CF... | **65C2...** |
| 18409549 | 65C2... | D3CF... |
| 18409550+ | D3CF... | D3CF... |

## Testing

- [ ] New node can sync past height 18409548
- [ ] Existing nodes continue to operate normally
- [ ] blsKey validation works correctly for heights > 18409547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Height-aware validator handling: improved BLS key validation around a protocol fork to avoid accepting invalid keys after the fork while preserving historical entries before it.
  * Added logging for BLS key decoding failures.

* **New Features**
  * Added a configurable fork-height setting controlling when stricter BLS key checks apply.

* **Chores**
  * Sequencer/validator update flow now uses block height to ensure correct validator set updates across fork transitions.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->