### PR TITLE
feat(node): add version subcommand to morphnode

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -1,8 +1,12 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
+GITCOMMIT := $(shell git rev-parse --short HEAD)
 GITDATE := $(shell git show -s --format='%ct')
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
+LDFLAGSSTRING +=-X main.Version=$(VERSION)
+LDFLAGSSTRING +=-X main.BuildTime=$(BUILD_TIME)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 morphnode:

--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -41,6 +41,7 @@ func main() {
 	app.Action = L2NodeMain
 	app.Commands = []cli.Command{
 		keyConverterCmd,
+		versionCmd,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/node/cmd/node/version.go
+++ b/node/cmd/node/version.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/urfave/cli"
+)
+
+// Version information, set via -ldflags
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)
+
+var versionCmd = cli.Command{
+	Name:    "version",
+	Aliases: []string{"v"},
+	Usage:   "show version information",
+	Action: func(ctx *cli.Context) error {
+		fmt.Printf("morphnode %s\n", Version)
+		fmt.Printf("Git Commit: %s\n", GitCommit)
+		fmt.Printf("Build Time: %s\n", BuildTime)
+		fmt.Printf("Go Version: %s\n", runtime.Version())
+		fmt.Printf("OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		return nil
+	},
+}


### PR DESCRIPTION
## Description

```
Add  `version` subcommand to display build information.
```

### Usage
```bash
morphnode version
```

### Output
```
morphnode v0.4.7
Git Commit: abc1234
Build Time: 2024-12-17T10:00:00Z
Go Version: go1.24.0
OS/Arch:    linux/amd64
```

### Changes
- Add `version.go` with version command
- Update Makefile to inject version info via ldflags
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a version command that displays the application version, Git commit hash, build time, Go runtime version, and system architecture information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->