### PR TITLE
support derive commitBatchWithProof event

### DIFF
--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -471,7 +471,7 @@ func (d *Derivation) UnPackData(data []byte) (geth.RPCRollupBatch, error) {
 	} else if bytes.Equal(d.rollupABI.Methods["commitBatchWithProof"].ID, data[:4]) {
 		args, err := d.rollupABI.Methods["commitBatchWithProof"].Inputs.Unpack(data[4:])
 		if err != nil {
-			return batch, fmt.Errorf("commitBatchWithProof submitBatches Unpack error:%v", err)
+			return batch, fmt.Errorf("commitBatchWithProof Unpack error:%v", err)
 		}
 		rollupBatchData := args[0].(struct {
 			Version           uint8     "json:\"version\""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added handling for an additional batch transaction variant so batch payloads that include proofs are recognized and processed.
  * Newly supported batch fields (version, parent headers, last block number, message counts and state/withdrawal roots) are extracted and populated into rollup batch records.
  * Returns a clear error when payload unpacking fails to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->