### PR TITLE
feat: add NewL2BlockV2 support in executor + RetryableClient

### DIFF
--- a/node/core/executor.go
+++ b/node/core/executor.go
@@ -535,41 +535,48 @@ func (e *Executor) RequestBlockDataV2(parentHashBytes []byte) (*l2node.BlockV2, 
 }
 
 // ApplyBlockV2 applies a block to the L2 execution layer.
-// This is used in sequencer mode after block validation.
-func (e *Executor) ApplyBlockV2(block *l2node.BlockV2) error {
-	// Convert BlockV2 to ExecutableL2Data for geth
+// This is a pass-through: upper layer (StateV2.ApplyBlock) handles idempotency
+// and reorg detection; lower layer (NewL2BlockV2 + SetCanonical) handles the
+// actual chain reorganization automatically.
+func (e *Executor) ApplyBlockV2(block *l2node.BlockV2) (applied bool, err error) {
 	execBlock := blockV2ToExecutableL2Data(block)
 
-	// Check if block is already applied
-	height, err := e.l2Client.BlockNumber(context.Background())
-	if err != nil {
-		return err
+	// Reorg / idempotent detection: only check when incoming block height
+	// is at or below the current geth head (normal sequential blocks skip this).
+	currentHeight, chkErr := e.l2Client.BlockNumber(context.Background())
+	if chkErr == nil && block.Number <= currentHeight {
+		existing, exErr := e.l2Client.BlockByNumber(context.Background(), big.NewInt(int64(block.Number)))
+		if exErr == nil && existing != nil {
+			if existing.Hash() == execBlock.Hash {
+				e.logger.Debug("ApplyBlockV2: idempotent skip", "number", execBlock.Number)
+				return false, nil
+			}
+			e.logger.Info("ApplyBlockV2: REORG detected",
+				"targetHeight", execBlock.Number,
+				"newHash", execBlock.Hash.Hex(),
+				"existingHash", existing.Hash().Hex(),
+				"currentHead", currentHeight,
+			)
+		}
 	}
 
-	if execBlock.Number <= height {
-		e.logger.Info("ignore it, the block was already applied", "block number", execBlock.Number)
-		return nil
+	if err := e.l2Client.NewL2BlockV2(context.Background(), execBlock, false); err != nil {
+		e.logger.Error("failed to apply block v2",
+			"number", execBlock.Number,
+			"hash", execBlock.Hash.Hex(),
+			"parentHash", execBlock.ParentHash.Hex(),
+			"error", err)
+		return false, err
 	}
 
-	// We only accept continuous blocks
-	if execBlock.Number > height+1 {
-		return types.ErrWrongBlockNumber
-	}
-
-	// Apply the block (no batch hash in sequencer mode for now)
-	err = e.l2Client.NewL2Block(context.Background(), execBlock, nil)
-	if err != nil {
-		e.logger.Error("failed to apply block v2", "error", err)
-		return err
-	}
-
-	// Update L1 message index
 	e.updateNextL1MessageIndex(execBlock)
-
 	e.metrics.Height.Set(float64(execBlock.Number))
-	e.logger.Info("ApplyBlockV2 success", "number", execBlock.Number, "hash", execBlock.Hash.Hex())
+	e.logger.Info("ApplyBlockV2 success",
+		"number", execBlock.Number,
+		"hash", execBlock.Hash.Hex(),
+		"parentHash", execBlock.ParentHash.Hex())
 
-	return nil
+	return true, nil
 }
 
 // GetBlockByNumber retrieves a block by its number from the L2 execution layer.

--- a/node/types/retryable_client.go
+++ b/node/types/retryable_client.go
@@ -29,6 +29,8 @@ const (
 	ExecutionAborted        = "execution aborted"
 	Timeout                 = "timed out"
 	DiscontinuousBlockError = "discontinuous block number"
+	WrongBlockNumberError   = "wrong block number"
+	ParentNotFoundError     = "parent block not found"
 
 	// Geth connection retry settings
 	GethRetryAttempts       = 60              // max retry attempts
@@ -356,6 +358,28 @@ func (rc *RetryableClient) NewL2Block(ctx context.Context, executableL2Data *cat
 	return
 }
 
+func (rc *RetryableClient) NewL2BlockV2(ctx context.Context, executableL2Data *catalyst.ExecutableL2Data, isSafe bool) (err error) {
+	rc.switchClient(ctx, executableL2Data.Timestamp, executableL2Data.Number)
+
+	if retryErr := backoff.Retry(func() error {
+		respErr := rc.aClient().NewL2BlockV2(ctx, executableL2Data, isSafe)
+		if respErr != nil {
+			rc.logger.Error("NewL2BlockV2 failed",
+				"block_number", executableL2Data.Number,
+				"isSafe", isSafe,
+				"error", respErr)
+			if retryableError(respErr) {
+				return respErr
+			}
+			err = respErr
+		}
+		return nil
+	}, rc.b); retryErr != nil {
+		return retryErr
+	}
+	return
+}
+
 func (rc *RetryableClient) NewSafeL2Block(ctx context.Context, safeL2Data *catalyst.SafeL2Data) (ret *eth.Header, err error) {
 	rc.switchClient(ctx, safeL2Data.Timestamp, safeL2Data.Number)
 	if retryErr := backoff.Retry(func() error {
@@ -516,16 +540,13 @@ func (rc *RetryableClient) SetBlockTags(ctx context.Context, safeBlockHash commo
 	return
 }
 
-// currently we want every error retryable, except the DiscontinuousBlockError
+// retryableError returns true for transient errors that should be retried.
+// Permanent logic errors (wrong block number, missing parent) are not retried.
 func retryableError(err error) bool {
-	// return strings.Contains(err.Error(), ConnectionRefused) ||
-	// 	strings.Contains(err.Error(), EOFError) ||
-	// 	strings.Contains(err.Error(), JWTStaleToken) ||
-	// 	strings.Contains(err.Error(), JWTExpiredToken) ||
-	// 	strings.Contains(err.Error(), MinerClosed) ||
-	// 	strings.Contains(err.Error(), ExecutionAborted) ||
-	// 	strings.Contains(err.Error(), Timeout)
-	return !strings.Contains(err.Error(), DiscontinuousBlockError)
+	msg := err.Error()
+	return !strings.Contains(msg, DiscontinuousBlockError) &&
+		!strings.Contains(msg, WrongBlockNumberError) &&
+		!strings.Contains(msg, ParentNotFoundError)
 }
 
 // ============================================================================

--- a/node/types/retryable_client.go
+++ b/node/types/retryable_client.go
@@ -32,6 +32,14 @@ const (
 	WrongBlockNumberError   = "wrong block number"
 	ParentNotFoundError     = "parent block not found"
 
+	// Block validation errors raised by geth (see go-ethereum/eth/catalyst/l2_api.go
+	// NewL2BlockV2 and go-ethereum/core/blockchain_l2.go writeBlockStateWithoutHead).
+	// These indicate the block payload is permanently invalid (signature replay,
+	// tampered field, or local corruption); retrying with the same payload will
+	// always fail and only delay error surfacing to the consensus layer.
+	BlockHashMismatchError     = "block hash mismatch"
+	InvalidNextL1MsgIndexError = "invalid block.NextL1MsgIndex"
+
 	// Geth connection retry settings
 	GethRetryAttempts       = 60              // max retry attempts
 	GethRetryInterval       = 5 * time.Second // interval between retries
@@ -541,12 +549,16 @@ func (rc *RetryableClient) SetBlockTags(ctx context.Context, safeBlockHash commo
 }
 
 // retryableError returns true for transient errors that should be retried.
-// Permanent logic errors (wrong block number, missing parent) are not retried.
+// Permanent logic errors (wrong block number, missing parent) and block
+// validation errors (hash mismatch, invalid NextL1MsgIndex) are not retried,
+// because the same payload will always fail and only delay error surfacing.
 func retryableError(err error) bool {
 	msg := err.Error()
 	return !strings.Contains(msg, DiscontinuousBlockError) &&
 		!strings.Contains(msg, WrongBlockNumberError) &&
-		!strings.Contains(msg, ParentNotFoundError)
+		!strings.Contains(msg, ParentNotFoundError) &&
+		!strings.Contains(msg, BlockHashMismatchError) &&
+		!strings.Contains(msg, InvalidNextL1MsgIndexError)
 }
 
 // ============================================================================

--- a/node/types/retryable_client_test.go
+++ b/node/types/retryable_client_test.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableError(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil-safe (transient connection refused)",
+			err:       errors.New("dial tcp 127.0.0.1:8551: connect: connection refused"),
+			retryable: true,
+		},
+		{
+			name:      "miner closed (transient)",
+			err:       errors.New(MinerClosed),
+			retryable: true,
+		},
+		{
+			name:      "discontinuous block (permanent)",
+			err:       fmt.Errorf("cannot new block with %s 11, expected 12", DiscontinuousBlockError),
+			retryable: false,
+		},
+		{
+			name:      "wrong block number (permanent)",
+			err:       fmt.Errorf("%s: expected 5, got 9", WrongBlockNumberError),
+			retryable: false,
+		},
+		{
+			name:      "parent not found (permanent)",
+			err:       fmt.Errorf("%s: 0xdeadbeef", ParentNotFoundError),
+			retryable: false,
+		},
+		{
+			name:      "block hash mismatch (permanent, security)",
+			err:       fmt.Errorf("%s: declared 0xaaa, computed 0xbbb", BlockHashMismatchError),
+			retryable: false,
+		},
+		{
+			name:      "invalid NextL1MsgIndex (permanent, security)",
+			err:       fmt.Errorf("%s at #100 0xabc: header=99, computed=42", InvalidNextL1MsgIndexError),
+			retryable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.retryable, retryableError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `Executor.ApplyBlockV2` returns `(applied bool, err error)` to let callers distinguish real applies from idempotent skips, preventing `StateV2.latestBlock` regression during HA Raft log replay
- `RetryableClient.NewL2BlockV2` wraps the new `engine_newL2BlockV2` RPC with retry, excluding `WrongBlockNumberError` / `ParentNotFoundError` from retry
- `RetryableClient.AssembleL2BlockV2` added for parent-hash-based block assembly

## Test plan

- [x] `go build ./node/...` — compiles cleanly
- [x] `UPGRADE_HEIGHT=10 ./run-test.sh test` — full devnet test passed (PBFT → Sequencer → fullnode sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)