### PR TITLE
refactor(node): remove zk-to-mpt migration cleanup leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ contracts/mainnet.json
 
 # logs
 *.log
-
-# mpt-switch-test (local testing only)
-ops/mpt-switch-test

--- a/node/core/batch.go
+++ b/node/core/batch.go
@@ -178,17 +178,6 @@ func (e *Executor) CalculateCapWithProposalBlock(currentBlockBytes []byte, curre
 		return false, err
 	}
 
-	// Jade fork: force batch points on the 1st and 2nd post-fork blocks, so the 1st post-fork block
-	// becomes a single-block batch: [H1, H2).
-	force, err := e.forceBatchPointForJadeFork(height, block.Timestamp, block.StateRoot, block.Hash)
-	if err != nil {
-		return false, err
-	}
-	if force {
-		e.logger.Info("Jade fork: force batch point", "height", height, "timestamp", block.Timestamp)
-		return true, nil
-	}
-
 	var exceeded bool
 	if e.isBatchUpgraded(block.Timestamp) {
 		exceeded, err = e.batchingCache.batchData.WillExceedCompressedSizeLimit(e.batchingCache.currentBlockContext, e.batchingCache.currentTxsPayload)
@@ -196,79 +185,6 @@ func (e *Executor) CalculateCapWithProposalBlock(currentBlockBytes []byte, curre
 		exceeded, err = e.batchingCache.batchData.EstimateCompressedSizeWithNewPayload(e.batchingCache.currentTxsPayload)
 	}
 	return exceeded, err
-}
-
-// forceBatchPointForJadeFork forces batch points at the 1st and 2nd block after the Jade fork time.
-//
-// Design goals:
-// - Minimal change: only affects batch-point decision logic.
-// - Stability: CalculateCapWithProposalBlock can be called multiple times at the same height; return must be consistent.
-// - Performance: after handling (or skipping beyond) the fork boundary, no more HeaderByNumber calls are made.
-func (e *Executor) forceBatchPointForJadeFork(height uint64, blockTime uint64, stateRoot common.Hash, blockHash common.Hash) (bool, error) {
-	// If we already decided to force at this height, keep returning true without extra RPCs.
-	if e.jadeForkForceHeight == height && height != 0 {
-		return true, nil
-	}
-	// If fork boundary is already handled and this isn't a forced height, fast exit.
-	if e.jadeForkStage >= 2 {
-		return false, nil
-	}
-
-	// Ensure we have fork time cached (0 means disabled).
-	if e.jadeForkTime == 0 {
-		e.jadeForkTime = e.l2Client.JadeForkTime()
-	}
-	forkTime := e.jadeForkTime
-	if forkTime == 0 || blockTime < forkTime {
-		return false, nil
-	}
-	if height == 0 {
-		return false, nil
-	}
-
-	// Check parent block time to detect the 1st post-fork block (H1).
-	parent, err := e.l2Client.HeaderByNumber(context.Background(), big.NewInt(int64(height-1)))
-	if err != nil {
-		return false, err
-	}
-	if parent.Time < forkTime {
-		// Log H1 (the 1st post-fork block) state root
-		// This stateRoot is intended to be used as the Rollup contract "genesis state root"
-		// when we reset/re-initialize the genesis state root during the Jade upgrade.
-		e.logger.Info(
-			"JADE_FORK_H1_GENESIS_STATE_ROOT",
-			"height", height,
-			"timestamp", blockTime,
-			"forkTime", forkTime,
-			"stateRoot", stateRoot.Hex(),
-			"blockHash", blockHash.Hex(),
-		)
-		e.jadeForkStage = 1
-		e.jadeForkForceHeight = height
-		return true, nil
-	}
-
-	// If parent is already post-fork, we may be at the 2nd post-fork block (H2) or later.
-	if height < 2 {
-		// We cannot be H2; mark done to avoid future calls.
-		e.jadeForkStage = 2
-		return false, nil
-	}
-
-	grandParent, err := e.l2Client.HeaderByNumber(context.Background(), big.NewInt(int64(height-2)))
-	if err != nil {
-		return false, err
-	}
-	if grandParent.Time < forkTime {
-		// This is H2 (2nd post-fork block).
-		e.jadeForkStage = 2
-		e.jadeForkForceHeight = height
-		return true, nil
-	}
-
-	// Beyond H2: nothing to do (can't retroactively fix). Mark done for performance.
-	e.jadeForkStage = 2
-	return false, nil
 }
 
 func (e *Executor) AppendBlsData(height int64, batchHash []byte, data l2node.BlsData) error {

--- a/node/core/config.go
+++ b/node/core/config.go
@@ -32,7 +32,6 @@ var (
 
 type Config struct {
 	L2                            *types.L2Config `json:"l2"`
-	L2Next                        *types.L2Config `json:"l2_next,omitempty"` // optional, for geth upgrade switch
 	L2CrossDomainMessengerAddress common.Address  `json:"cross_domain_messenger_address"`
 	SequencerAddress              common.Address  `json:"sequencer_address"`
 	GovAddress                    common.Address  `json:"gov_address"`
@@ -47,7 +46,6 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		L2:                            new(types.L2Config),
-		L2Next:                        nil, // optional, only for upgrade switch
 		Logger:                        tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)),
 		MaxL1MessageNumPerBlock:       100,
 		L2CrossDomainMessengerAddress: predeploys.L2CrossDomainMessengerAddr,
@@ -128,16 +126,6 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 	c.L2.EngineAddr = l2EngineAddr
 	c.L2.JwtSecret = secret
 
-	// L2Next is optional - only for upgrade switch (e.g., ZK to MPT)
-	l2NextEthAddr := ctx.GlobalString(flags.L2NextEthAddr.Name)
-	l2NextEngineAddr := ctx.GlobalString(flags.L2NextEngineAddr.Name)
-	if l2NextEthAddr != "" && l2NextEngineAddr != "" {
-		c.L2Next = &types.L2Config{
-			EthAddr:    l2NextEthAddr,
-			EngineAddr: l2NextEngineAddr,
-			JwtSecret:  secret, // same secret
-		}
-	}
 	if ctx.GlobalIsSet(flags.MaxL1MessageNumPerBlock.Name) {
 		c.MaxL1MessageNumPerBlock = ctx.GlobalUint64(flags.MaxL1MessageNumPerBlock.Name)
 		if c.MaxL1MessageNumPerBlock == 0 {

--- a/node/core/executor.go
+++ b/node/core/executor.go
@@ -56,13 +56,6 @@ type Executor struct {
 	rollupABI             *abi.ABI
 	batchingCache         *BatchingCache
 
-	// Jade fork handling: force batch points at the 1st and 2nd block after fork.
-	// This state machine exists to avoid repeated HeaderByNumber calls after the fork is handled,
-	// while keeping results stable if CalculateCapWithProposalBlock is called multiple times at the same height.
-	jadeForkTime        uint64 // cached from geth eth_config.morph.jadeForkTime (0 means disabled/unknown)
-	jadeForkStage       uint8  // 0: not handled, 1: forced H1, 2: done (forced H2 or skipped beyond H2)
-	jadeForkForceHeight uint64 // if equals current height, must return true (stability across multiple calls)
-
 	logger  tmlog.Logger
 	metrics *Metrics
 }
@@ -78,7 +71,6 @@ func getNextL1MsgIndex(client *types.RetryableClient) (uint64, error) {
 func NewExecutor(newSyncFunc NewSyncerFunc, config *Config, tmPubKey crypto.PubKey) (*Executor, error) {
 	logger := config.Logger
 	logger = logger.With("module", "executor")
-	// L2 geth endpoint (required - current geth)
 	aClient, err := authclient.DialContext(context.Background(), config.L2.EngineAddr, config.L2.JwtSecret)
 	if err != nil {
 		return nil, err
@@ -88,31 +80,7 @@ func NewExecutor(newSyncFunc NewSyncerFunc, config *Config, tmPubKey crypto.PubK
 		return nil, err
 	}
 
-	// L2Next endpoint (optional - for upgrade switch)
-	var aNextClient *authclient.Client
-	var eNextClient *ethclient.Client
-	if config.L2Next != nil && config.L2Next.EngineAddr != "" && config.L2Next.EthAddr != "" {
-		aNextClient, err = authclient.DialContext(context.Background(), config.L2Next.EngineAddr, config.L2Next.JwtSecret)
-		if err != nil {
-			return nil, err
-		}
-		eNextClient, err = ethclient.Dial(config.L2Next.EthAddr)
-		if err != nil {
-			return nil, err
-		}
-		logger.Info("L2Next geth configured (upgrade switch enabled)", "engineAddr", config.L2Next.EngineAddr, "ethAddr", config.L2Next.EthAddr)
-	} else {
-		logger.Info("L2Next geth not configured (no upgrade switch)")
-	}
-
-	// Fetch geth config at startup (with retry to wait for geth)
-	gethCfg, err := types.FetchGethConfigWithRetry(config.L2.EthAddr, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch geth config: %w", err)
-	}
-	logger.Info("Geth config fetched", "switchTime", gethCfg.SwitchTime, "useZktrie", gethCfg.UseZktrie)
-
-	l2Client := types.NewRetryableClient(aClient, eClient, aNextClient, eNextClient, gethCfg.SwitchTime, logger)
+	l2Client := types.NewRetryableClient(aClient, eClient, logger)
 	index, err := getNextL1MsgIndex(l2Client)
 	if err != nil {
 		return nil, err
@@ -155,7 +123,6 @@ func NewExecutor(newSyncFunc NewSyncerFunc, config *Config, tmPubKey crypto.PubK
 		batchingCache:         NewBatchingCache(),
 		UpgradeBatchTime:      config.UpgradeBatchTime,
 		blsKeyCheckForkHeight: config.BlsKeyCheckForkHeight,
-		jadeForkTime:          l2Client.JadeForkTime(),
 		logger:                logger,
 		metrics:               PrometheusMetrics("morphnode"),
 	}
@@ -317,38 +284,18 @@ func (e *Executor) DeliverBlock(txs [][]byte, metaData []byte, consensusData l2n
 
 	if wrappedBlock.Number <= height {
 		e.logger.Info("block already delivered by geth (via P2P sync)", "block_number", wrappedBlock.Number)
-		// Even if block was already delivered (e.g., synced via P2P), we still need to check
-		// if MPT switch should happen, otherwise sentry nodes won't switch to the correct geth.
-		e.l2Client.EnsureSwitched(context.Background(), wrappedBlock.Timestamp, wrappedBlock.Number)
-
-		// After switch, re-check height from the new geth client
-		// The block might exist in legacy geth but not in target geth after switch
-		newHeight, err := e.l2Client.BlockNumber(context.Background())
-		if err != nil {
-			return nil, nil, err
+		if e.devSequencer {
+			return nil, consensusData.ValidatorSet, nil
 		}
-		if wrappedBlock.Number > newHeight {
-			e.logger.Info("block not in target geth after switch, need to deliver",
-				"block_number", wrappedBlock.Number,
-				"old_height", height,
-				"new_height", newHeight)
-			// Update height and continue to deliver the block
-			height = newHeight
-		} else {
-			if e.devSequencer {
-				return nil, consensusData.ValidatorSet, nil
-			}
-			return e.getParamsAndValsAtHeight(int64(wrappedBlock.Number))
-		}
+		return e.getParamsAndValsAtHeight(int64(wrappedBlock.Number))
 	}
 
 	// We only accept the continuous blocks for now.
 	// It acts like full sync. Snap sync is not enabled until the Geth enables snapshot with zkTrie
 	if wrappedBlock.Number > height+1 {
-		e.logger.Error("!!! CRITICAL: Geth is behind - node BLOCKED !!!",
+		e.logger.Error("geth is behind",
 			"consensus_block", wrappedBlock.Number,
-			"geth_height", height,
-			"action", "Switch to MPT-compatible geth IMMEDIATELY")
+			"geth_height", height)
 		return nil, nil, types.ErrWrongBlockNumber
 	}
 
@@ -380,15 +327,10 @@ func (e *Executor) DeliverBlock(txs [][]byte, metaData []byte, consensusData l2n
 	}
 	err = e.l2Client.NewL2Block(context.Background(), l2Block, batchHash)
 	if err != nil {
-		e.logger.Error("========================================")
-		e.logger.Error("CRITICAL: Failed to deliver block to geth!")
-		e.logger.Error("========================================")
 		e.logger.Error("failed to NewL2Block",
 			"error", err,
 			"block_number", l2Block.Number,
 			"block_timestamp", l2Block.Timestamp)
-		e.logger.Error("HINT: If this occurs after MPT upgrade, your geth node may not support MPT blocks. " +
-			"Please ensure you are running an MPT-compatible geth node.")
 		return nil, nil, err
 	}
 

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -34,7 +34,6 @@ const (
 type Config struct {
 	L1                    *types.L1Config `json:"l1"`
 	L2                    *types.L2Config `json:"l2"`
-	L2Next                *types.L2Config `json:"l2_next,omitempty"` // optional, for geth upgrade switch
 	BeaconRpc             string          `json:"beacon_rpc"`
 	RollupContractAddress common.Address  `json:"rollup_contract_address"`
 	StartHeight           uint64          `json:"start_height"`
@@ -56,7 +55,6 @@ func DefaultConfig() *Config {
 		LogProgressInterval: DefaultLogProgressInterval,
 		FetchBlockRange:     DefaultFetchBlockRange,
 		L2:                  new(types.L2Config),
-		L2Next:              nil, // optional, only for upgrade switch
 	}
 }
 
@@ -138,16 +136,6 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 	c.L2.EngineAddr = l2EngineAddr
 	c.L2.JwtSecret = secret
 
-	// L2Next is optional - only for upgrade switch (e.g., ZK to MPT)
-	l2NextEthAddr := ctx.GlobalString(flags.L2NextEthAddr.Name)
-	l2NextEngineAddr := ctx.GlobalString(flags.L2NextEngineAddr.Name)
-	if l2NextEthAddr != "" && l2NextEngineAddr != "" {
-		c.L2Next = &types.L2Config{
-			EthAddr:    l2NextEthAddr,
-			EngineAddr: l2NextEngineAddr,
-			JwtSecret:  secret, // same secret
-		}
-	}
 	c.MetricsServerEnable = ctx.GlobalBool(flags.MetricsServerEnable.Name)
 	c.MetricsHostname = ctx.GlobalString(flags.MetricsHostname.Name)
 	c.MetricsPort = ctx.GlobalUint64(flags.MetricsPort.Name)

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -63,10 +63,6 @@ type Derivation struct {
 	pollInterval        time.Duration
 	logProgressInterval time.Duration
 	stop                chan struct{}
-
-	// geth upgrade config (fetched once at startup)
-	switchTime uint64
-	useZktrie  bool
 }
 
 type DeployContractBackend interface {
@@ -81,7 +77,6 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 	if err != nil {
 		return nil, err
 	}
-	// L2 geth endpoint (required - current geth)
 	aClient, err := authclient.DialContext(context.Background(), cfg.L2.EngineAddr, cfg.L2.JwtSecret)
 	if err != nil {
 		return nil, err
@@ -89,23 +84,6 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 	eClient, err := ethclient.Dial(cfg.L2.EthAddr)
 	if err != nil {
 		return nil, err
-	}
-
-	// L2Next endpoint (optional - for upgrade switch)
-	var aNextClient *authclient.Client
-	var eNextClient *ethclient.Client
-	if cfg.L2Next != nil && cfg.L2Next.EngineAddr != "" && cfg.L2Next.EthAddr != "" {
-		aNextClient, err = authclient.DialContext(context.Background(), cfg.L2Next.EngineAddr, cfg.L2Next.JwtSecret)
-		if err != nil {
-			return nil, err
-		}
-		eNextClient, err = ethclient.Dial(cfg.L2Next.EthAddr)
-		if err != nil {
-			return nil, err
-		}
-		logger.Info("L2Next geth configured (upgrade switch enabled)", "engineAddr", cfg.L2Next.EngineAddr, "ethAddr", cfg.L2Next.EthAddr)
-	} else {
-		logger.Info("L2Next geth not configured (no upgrade switch)")
 	}
 
 	msgPasser, err := bindings.NewL2ToL1MessagePasser(predeploys.L2ToL1MessagePasserAddr, eClient)
@@ -139,14 +117,6 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 	baseHttp := NewBasicHTTPClient(cfg.BeaconRpc, logger)
 	l1BeaconClient := NewL1BeaconClient(baseHttp)
 
-	// Fetch geth config once at startup for root validation skip logic (with retry)
-	gethCfg, err := types.FetchGethConfigWithRetry(cfg.L2.EthAddr, logger)
-	if err != nil {
-		cancel() // cancel context to avoid leak
-		return nil, fmt.Errorf("failed to fetch geth config: %w", err)
-	}
-	logger.Info("Geth config fetched", "switchTime", gethCfg.SwitchTime, "useZktrie", gethCfg.UseZktrie)
-
 	return &Derivation{
 		ctx:                   ctx,
 		db:                    db,
@@ -160,7 +130,7 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 		logger:                logger,
 		RollupContractAddress: cfg.RollupContractAddress,
 		confirmations:         cfg.L1.Confirmations,
-		l2Client:              types.NewRetryableClient(aClient, eClient, aNextClient, eNextClient, gethCfg.SwitchTime, logger),
+		l2Client:              types.NewRetryableClient(aClient, eClient, logger),
 		cancel:                cancel,
 		stop:                  make(chan struct{}),
 		startHeight:           cfg.StartHeight,
@@ -171,8 +141,6 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 		metrics:               metrics,
 		l1BeaconClient:        l1BeaconClient,
 		L2ToL1MessagePasser:   msgPasser,
-		switchTime:            gethCfg.SwitchTime,
-		useZktrie:             gethCfg.UseZktrie,
 	}, nil
 }
 
@@ -284,40 +252,21 @@ func (d *Derivation) derivationBlock(ctx context.Context) {
 		withdrawalMismatch := !bytes.Equal(withdrawalRoot[:], batchInfo.withdrawalRoot.Bytes())
 
 		if rootMismatch || withdrawalMismatch {
-			// Check if should skip validation during upgrade transition
-			// Skip if: (before switch && MPT geth) or (after switch && ZK geth)
-			skipValidation := false
-			if d.switchTime > 0 {
-				beforeSwitch := lastHeader.Time < d.switchTime
-				if (beforeSwitch && !d.useZktrie) || (!beforeSwitch && d.useZktrie) {
-					skipValidation = true
-					d.logger.Info("Root validation skipped during upgrade transition",
-						"originStateRootHash", batchInfo.root,
-						"deriveStateRootHash", lastHeader.Root.Hex(),
-						"blockTimestamp", lastHeader.Time,
-						"switchTime", d.switchTime,
-						"useZktrie", d.useZktrie,
-					)
+			d.metrics.SetBatchStatus(stateException)
+			// TODO The challenge switch is currently on and will be turned on in the future
+			if d.validator != nil && d.validator.ChallengeEnable() {
+				if err := d.validator.ChallengeState(batchInfo.batchIndex); err != nil {
+					d.logger.Error("challenge state failed")
+					return
 				}
 			}
-
-			if !skipValidation {
-				d.metrics.SetBatchStatus(stateException)
-				// TODO The challenge switch is currently on and will be turned on in the future
-				if d.validator != nil && d.validator.ChallengeEnable() {
-					if err := d.validator.ChallengeState(batchInfo.batchIndex); err != nil {
-						d.logger.Error("challenge state failed")
-						return
-					}
-				}
-				d.logger.Error("root hash or withdrawal hash is not equal",
-					"originStateRootHash", batchInfo.root,
-					"deriveStateRootHash", lastHeader.Root.Hex(),
-					"batchWithdrawalRoot", batchInfo.withdrawalRoot.Hex(),
-					"deriveWithdrawalRoot", common.BytesToHash(withdrawalRoot[:]).Hex(),
-				)
-				return
-			}
+			d.logger.Error("root hash or withdrawal hash is not equal",
+				"originStateRootHash", batchInfo.root,
+				"deriveStateRootHash", lastHeader.Root.Hex(),
+				"batchWithdrawalRoot", batchInfo.withdrawalRoot.Hex(),
+				"deriveWithdrawalRoot", common.BytesToHash(withdrawalRoot[:]).Hex(),
+			)
+			return
 		}
 		d.metrics.SetBatchStatus(stateNormal)
 		d.metrics.SetL1SyncHeight(lg.BlockNumber)

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -256,7 +256,7 @@ func (d *Derivation) derivationBlock(ctx context.Context) {
 			// TODO The challenge switch is currently on and will be turned on in the future
 			if d.validator != nil && d.validator.ChallengeEnable() {
 				if err := d.validator.ChallengeState(batchInfo.batchIndex); err != nil {
-					d.logger.Error("challenge state failed")
+					d.logger.Error("challenge state failed", "batchIndex", batchInfo.batchIndex, "error", err)
 					return
 				}
 			}

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -32,18 +32,6 @@ var (
 		EnvVar: prefixEnvVar("L2_ENGINE_RPC"),
 	}
 
-	L2NextEthAddr = cli.StringFlag{
-		Name:   "l2next.eth",
-		Usage:  "Address of next L2 geth JSON-RPC endpoints to switch to (optional, for upgrades)",
-		EnvVar: prefixEnvVar("L2_NEXT_ETH_RPC"),
-	}
-
-	L2NextEngineAddr = cli.StringFlag{
-		Name:   "l2next.engine",
-		Usage:  "Address of next L2 geth Engine JSON-RPC endpoints to switch to (optional, for upgrades)",
-		EnvVar: prefixEnvVar("L2_NEXT_ENGINE_RPC"),
-	}
-
 	L2EngineJWTSecret = cli.StringFlag{
 		Name:        "l2.jwt-secret",
 		Usage:       "Path to JWT secret key. Keys are 32 bytes, hex encoded in a file. A new key will be generated if left empty.",
@@ -359,8 +347,6 @@ var Flags = []cli.Flag{
 	L2EthAddr,
 	L2EngineAddr,
 	L2EngineJWTSecret,
-	L2NextEthAddr,
-	L2NextEngineAddr,
 	MaxL1MessageNumPerBlock,
 	L2CrossDomainMessengerContractAddr,
 	L2SequencerAddr,

--- a/node/types/retryable_client.go
+++ b/node/types/retryable_client.go
@@ -2,11 +2,8 @@ package types
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"math/big"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -16,7 +13,6 @@ import (
 	"github.com/morph-l2/go-ethereum/eth/catalyst"
 	"github.com/morph-l2/go-ethereum/ethclient"
 	"github.com/morph-l2/go-ethereum/ethclient/authclient"
-	"github.com/morph-l2/go-ethereum/rpc"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
@@ -30,283 +26,38 @@ const (
 	Timeout                 = "timed out"
 	DiscontinuousBlockError = "discontinuous block number"
 
-	// Geth connection retry settings
-	GethRetryAttempts       = 60              // max retry attempts
-	GethRetryInterval       = 5 * time.Second // interval between retries
 	GethRetryMaxElapsedTime = 30 * time.Minute
 )
 
-// configResponse represents the eth_config RPC response (EIP-7910)
-type configResponse struct {
-	Current *forkConfig `json:"current"`
-	Next    *forkConfig `json:"next"`
-	Last    *forkConfig `json:"last"`
-}
-
-// forkConfig represents a single fork configuration
-type forkConfig struct {
-	ActivationTime  uint64            `json:"activationTime"`
-	ChainId         string            `json:"chainId"`
-	ForkId          string            `json:"forkId"`
-	Precompiles     map[string]string `json:"precompiles"`
-	SystemContracts map[string]string `json:"systemContracts"`
-	Morph           *morphExtension   `json:"morph,omitempty"`
-}
-
-// morphExtension contains Morph-specific configuration fields
-type morphExtension struct {
-	UseZktrie    bool    `json:"useZktrie"`
-	JadeForkTime *uint64 `json:"jadeForkTime,omitempty"`
-}
-
-// GethConfig holds the configuration fetched from geth via eth_config API
-type GethConfig struct {
-	SwitchTime uint64
-	UseZktrie  bool
-}
-
-// FetchGethConfigWithRetry fetches geth config with retry, waiting for geth to be ready.
-func FetchGethConfigWithRetry(rpcURL string, logger tmlog.Logger) (*GethConfig, error) {
-	var lastErr error
-	for i := 0; i < GethRetryAttempts; i++ {
-		config, err := FetchGethConfig(rpcURL, logger)
-		if err == nil {
-			return config, nil
-		}
-		lastErr = err
-		logger.Info("Waiting for geth to be ready...", "attempt", i+1, "error", err)
-		time.Sleep(GethRetryInterval)
-	}
-	return nil, fmt.Errorf("geth not ready after %d attempts: %w", GethRetryAttempts, lastErr)
-}
-
-// FetchGethConfig fetches the geth configuration via eth_config API
-func FetchGethConfig(rpcURL string, logger tmlog.Logger) (*GethConfig, error) {
-	client, err := rpc.Dial(rpcURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to geth: %w", err)
-	}
-	defer client.Close()
-
-	var result json.RawMessage
-	if err := client.Call(&result, "eth_config"); err != nil {
-		return nil, fmt.Errorf("eth_config call failed: %w", err)
-	}
-
-	var resp configResponse
-	if err := json.Unmarshal(result, &resp); err != nil {
-		return nil, fmt.Errorf("failed to parse eth_config response: %w", err)
-	}
-
-	config := &GethConfig{}
-
-	// Get useZktrie from current config
-	if resp.Current != nil && resp.Current.Morph != nil {
-		config.UseZktrie = resp.Current.Morph.UseZktrie
-		logger.Info("Fetched useZktrie from geth", "useZktrie", config.UseZktrie)
-	}
-
-	// Try to get jadeForkTime from current config
-	if resp.Current != nil && resp.Current.Morph != nil && resp.Current.Morph.JadeForkTime != nil {
-		config.SwitchTime = *resp.Current.Morph.JadeForkTime
-		logger.Info("Fetched Jade fork time from geth", "jadeForkTime", config.SwitchTime, "source", "current")
-		return config, nil
-	}
-
-	// Fallback to next config
-	if resp.Next != nil && resp.Next.Morph != nil && resp.Next.Morph.JadeForkTime != nil {
-		config.SwitchTime = *resp.Next.Morph.JadeForkTime
-		logger.Info("Fetched Jade fork time from geth", "jadeForkTime", config.SwitchTime, "source", "next")
-		return config, nil
-	}
-
-	// Fallback to last config
-	if resp.Last != nil && resp.Last.Morph != nil && resp.Last.Morph.JadeForkTime != nil {
-		config.SwitchTime = *resp.Last.Morph.JadeForkTime
-		logger.Info("Fetched Jade fork time from geth", "jadeForkTime", config.SwitchTime, "source", "last")
-		return config, nil
-	}
-
-	logger.Info("Jade fork time not configured in geth, switch disabled")
-	return config, nil
-}
-
 type RetryableClient struct {
-	authClient     *authclient.Client // current geth
-	ethClient      *ethclient.Client  // current geth
-	nextAuthClient *authclient.Client // next geth (for upgrade switch)
-	nextEthClient  *ethclient.Client  // next geth (for upgrade switch)
-	switchTime     uint64             // timestamp to switch to next geth
-	switched       atomic.Bool        // whether switched to next geth
-	b              backoff.BackOff
-	logger         tmlog.Logger
+	authClient *authclient.Client
+	ethClient  *ethclient.Client
+	b          backoff.BackOff
+	logger     tmlog.Logger
 }
 
-// JadeForkTime returns the configured Jade fork/switch timestamp fetched from geth (eth_config).
-// Note: this is a local value stored in the client; it does not perform any RPC.
-func (rc *RetryableClient) JadeForkTime() uint64 {
-	return rc.switchTime
-}
-
-// NewRetryableClient creates a new retryable client with the given switch time.
-// Will retry calling the api, if the connection is refused.
-//
-// If nextAuthClient or nextEthClient is nil, switch is disabled and only current client is used.
-// This is useful for nodes that don't need to switch geth (most nodes).
-//
-// The switchTime should be fetched via FetchGethConfig before calling this function.
-func NewRetryableClient(authClient *authclient.Client, ethClient *ethclient.Client, nextAuthClient *authclient.Client, nextEthClient *ethclient.Client, switchTime uint64, logger tmlog.Logger) *RetryableClient {
+func NewRetryableClient(authClient *authclient.Client, ethClient *ethclient.Client, logger tmlog.Logger) *RetryableClient {
 	logger = logger.With("module", "retryClient")
-	// set MaxElapsedTime to 30 min
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = GethRetryMaxElapsedTime
-	// If next client is not configured, disable switch
-	if nextAuthClient == nil || nextEthClient == nil {
-		logger.Info("L2Next client not configured, switch disabled")
-		return &RetryableClient{
-			authClient:     authClient,
-			ethClient:      ethClient,
-			nextAuthClient: authClient, // fallback to current
-			nextEthClient:  ethClient,  // fallback to current
-			switchTime:     switchTime,
-			b:              bo,
-			logger:         logger,
-		}
-	}
-	// Check if switch time has already passed at startup
-	now := uint64(time.Now().Unix())
-	alreadySwitched := switchTime > 0 && now >= switchTime
-
-	if alreadySwitched {
-		logger.Info("Switch time already passed at startup, starting with next client",
-			"switchTime", switchTime,
-			"currentTime", now)
-	} else {
-		logger.Info("Geth switch enabled", "switchTime", switchTime)
-	}
-
-	rc := &RetryableClient{
-		authClient:     authClient,
-		ethClient:      ethClient,
-		nextAuthClient: nextAuthClient,
-		nextEthClient:  nextEthClient,
-		switchTime:     switchTime,
-		b:              bo,
-		logger:         logger,
-	}
-
-	// If switch time already passed, mark as switched immediately
-	if alreadySwitched {
-		rc.switched.Store(true)
-	}
-
-	return rc
-}
-
-func (rc *RetryableClient) aClient() *authclient.Client {
-	if !rc.switched.Load() {
-		return rc.authClient
-	}
-	return rc.nextAuthClient
-}
-
-func (rc *RetryableClient) eClient() *ethclient.Client {
-	if !rc.switched.Load() {
-		return rc.ethClient
-	}
-	return rc.nextEthClient
-}
-
-// EnsureSwitched checks if switch time has been reached and switches to next client if needed.
-// This should be called when the block is already delivered (e.g., synced via P2P) to ensure
-// the client switch happens even if NewL2Block is not called.
-func (rc *RetryableClient) EnsureSwitched(ctx context.Context, timeStamp uint64, number uint64) {
-	rc.switchClient(ctx, timeStamp, number)
-}
-
-func (rc *RetryableClient) switchClient(ctx context.Context, timeStamp uint64, number uint64) {
-	if rc.switched.Load() {
-		return
-	}
-	if rc.switchTime == 0 {
-		return
-	}
-	if timeStamp < rc.switchTime {
-		return
-	}
-
-	rc.logger.Info("========================================")
-	rc.logger.Info("GETH UPGRADE: Switch time reached!")
-	rc.logger.Info("========================================")
-	rc.logger.Info("Switch time reached, switching from current client to next client",
-		"switch_time", rc.switchTime,
-		"current_time", timeStamp,
-		"target_block", number)
-	rc.logger.Info("Current status: connected to current geth, waiting for next geth to sync...")
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	startTime := time.Now()
-	lastLogTime := startTime
-
-	for {
-		remote, err := rc.nextEthClient.BlockNumber(ctx)
-		if err != nil {
-			rc.logger.Error("Failed to get next geth block number",
-				"error", err,
-				"hint", "Please ensure next geth is running and accessible")
-			<-ticker.C
-			continue
-		}
-
-		if remote+1 >= number {
-			// Get next geth's latest block hash for debugging
-			targetHeader, headerErr := rc.nextEthClient.HeaderByNumber(ctx, big.NewInt(int64(remote)))
-			targetBlockHash := "unknown"
-			targetStateRoot := "unknown"
-			if headerErr == nil && targetHeader != nil {
-				targetBlockHash = targetHeader.Hash().Hex()
-				targetStateRoot = targetHeader.Root.Hex()
-			}
-
-			rc.switched.Store(true)
-			rc.logger.Info("========================================")
-			rc.logger.Info("GETH UPGRADE: Successfully switched!")
-			rc.logger.Info("========================================")
-			rc.logger.Info("Successfully switched to next client",
-				"remote_block", remote,
-				"target_block", number,
-				"target_block_hash", targetBlockHash,
-				"target_state_root", targetStateRoot,
-				"wait_duration", time.Since(startTime))
-			return
-		}
-
-		if time.Since(lastLogTime) >= 5*time.Second {
-			rc.logger.Error("!!! WAITING: Node BLOCKED waiting for next geth !!!",
-				"next_geth_block", remote,
-				"target_block", number,
-				"blocks_behind", number-remote-1,
-				"wait_duration", time.Since(startTime))
-			lastLogTime = time.Now()
-		}
-
-		<-ticker.C
+	return &RetryableClient{
+		authClient: authClient,
+		ethClient:  ethClient,
+		b:          bo,
+		logger:     logger,
 	}
 }
 
 func (rc *RetryableClient) AssembleL2Block(ctx context.Context, number *big.Int, transactions eth.Transactions) (ret *catalyst.ExecutableL2Data, err error) {
 	timestamp := uint64(time.Now().Unix())
 	if retryErr := backoff.Retry(func() error {
-		rc.switchClient(ctx, timestamp, number.Uint64())
-		resp, respErr := rc.aClient().AssembleL2Block(ctx, &timestamp, number, transactions)
+		resp, respErr := rc.authClient.AssembleL2Block(ctx, &timestamp, number, transactions)
 		if respErr != nil {
 			rc.logger.Info("failed to AssembleL2Block", "error", respErr)
 			if retryableError(respErr) {
 				return respErr
 			}
-			err = respErr // stop retrying and put this error to response error field, if the error is not connection related
+			err = respErr
 		}
 		ret = resp
 		return nil
@@ -317,9 +68,8 @@ func (rc *RetryableClient) AssembleL2Block(ctx context.Context, number *big.Int,
 }
 
 func (rc *RetryableClient) ValidateL2Block(ctx context.Context, executableL2Data *catalyst.ExecutableL2Data) (ret bool, err error) {
-	rc.switchClient(ctx, executableL2Data.Timestamp, executableL2Data.Number)
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.aClient().ValidateL2Block(ctx, executableL2Data)
+		resp, respErr := rc.authClient.ValidateL2Block(ctx, executableL2Data)
 		if respErr != nil {
 			rc.logger.Info("failed to ValidateL2Block", "error", respErr)
 			if retryableError(respErr) {
@@ -336,10 +86,8 @@ func (rc *RetryableClient) ValidateL2Block(ctx context.Context, executableL2Data
 }
 
 func (rc *RetryableClient) NewL2Block(ctx context.Context, executableL2Data *catalyst.ExecutableL2Data, batchHash *common.Hash) (err error) {
-	rc.switchClient(ctx, executableL2Data.Timestamp, executableL2Data.Number)
-
 	if retryErr := backoff.Retry(func() error {
-		respErr := rc.aClient().NewL2Block(ctx, executableL2Data, batchHash)
+		respErr := rc.authClient.NewL2Block(ctx, executableL2Data, batchHash)
 		if respErr != nil {
 			rc.logger.Error("NewL2Block failed",
 				"block_number", executableL2Data.Number,
@@ -357,9 +105,8 @@ func (rc *RetryableClient) NewL2Block(ctx context.Context, executableL2Data *cat
 }
 
 func (rc *RetryableClient) NewSafeL2Block(ctx context.Context, safeL2Data *catalyst.SafeL2Data) (ret *eth.Header, err error) {
-	rc.switchClient(ctx, safeL2Data.Timestamp, safeL2Data.Number)
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.aClient().NewSafeL2Block(ctx, safeL2Data)
+		resp, respErr := rc.authClient.NewSafeL2Block(ctx, safeL2Data)
 		if respErr != nil {
 			rc.logger.Info("failed to NewSafeL2Block", "error", respErr)
 			if retryableError(respErr) {
@@ -377,7 +124,7 @@ func (rc *RetryableClient) NewSafeL2Block(ctx context.Context, safeL2Data *catal
 
 func (rc *RetryableClient) CommitBatch(ctx context.Context, batch *eth.RollupBatch, signatures []eth.BatchSignature) (err error) {
 	if retryErr := backoff.Retry(func() error {
-		respErr := rc.aClient().CommitBatch(ctx, batch, signatures)
+		respErr := rc.authClient.CommitBatch(ctx, batch, signatures)
 		if respErr != nil {
 			rc.logger.Info("failed to CommitBatch", "error", respErr)
 			if retryableError(respErr) {
@@ -394,7 +141,7 @@ func (rc *RetryableClient) CommitBatch(ctx context.Context, batch *eth.RollupBat
 
 func (rc *RetryableClient) AppendBlsSignature(ctx context.Context, batchHash common.Hash, signature eth.BatchSignature) (err error) {
 	if retryErr := backoff.Retry(func() error {
-		respErr := rc.aClient().AppendBlsSignature(ctx, batchHash, signature)
+		respErr := rc.authClient.AppendBlsSignature(ctx, batchHash, signature)
 		if respErr != nil {
 			rc.logger.Info("failed to call AppendBlsSignature", "error", respErr)
 			if retryableError(respErr) {
@@ -411,7 +158,7 @@ func (rc *RetryableClient) AppendBlsSignature(ctx context.Context, batchHash com
 
 func (rc *RetryableClient) BlockNumber(ctx context.Context) (ret uint64, err error) {
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.eClient().BlockNumber(ctx)
+		resp, respErr := rc.ethClient.BlockNumber(ctx)
 		if respErr != nil {
 			rc.logger.Info("failed to call BlockNumber", "error", respErr)
 			if retryableError(respErr) {
@@ -429,7 +176,7 @@ func (rc *RetryableClient) BlockNumber(ctx context.Context) (ret uint64, err err
 
 func (rc *RetryableClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (ret *eth.Header, err error) {
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.eClient().HeaderByNumber(ctx, blockNumber)
+		resp, respErr := rc.ethClient.HeaderByNumber(ctx, blockNumber)
 		if respErr != nil {
 			rc.logger.Info("failed to call HeaderByNumber", "error", respErr)
 			if retryableError(respErr) {
@@ -465,7 +212,7 @@ func (rc *RetryableClient) BlockByNumber(ctx context.Context, blockNumber *big.I
 
 func (rc *RetryableClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) (ret []byte, err error) {
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.eClient().CallContract(ctx, call, blockNumber)
+		resp, respErr := rc.ethClient.CallContract(ctx, call, blockNumber)
 		if respErr != nil {
 			rc.logger.Info("failed to call eth_call", "error", respErr)
 			if retryableError(respErr) {
@@ -483,7 +230,7 @@ func (rc *RetryableClient) CallContract(ctx context.Context, call ethereum.CallM
 
 func (rc *RetryableClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) (ret []byte, err error) {
 	if retryErr := backoff.Retry(func() error {
-		resp, respErr := rc.eClient().CodeAt(ctx, contract, blockNumber)
+		resp, respErr := rc.ethClient.CodeAt(ctx, contract, blockNumber)
 		if respErr != nil {
 			rc.logger.Info("failed to call eth_getCode", "error", respErr)
 			if retryableError(respErr) {
@@ -518,13 +265,6 @@ func (rc *RetryableClient) SetBlockTags(ctx context.Context, safeBlockHash commo
 
 // currently we want every error retryable, except the DiscontinuousBlockError
 func retryableError(err error) bool {
-	// return strings.Contains(err.Error(), ConnectionRefused) ||
-	// 	strings.Contains(err.Error(), EOFError) ||
-	// 	strings.Contains(err.Error(), JWTStaleToken) ||
-	// 	strings.Contains(err.Error(), JWTExpiredToken) ||
-	// 	strings.Contains(err.Error(), MinerClosed) ||
-	// 	strings.Contains(err.Error(), ExecutionAborted) ||
-	// 	strings.Contains(err.Error(), Timeout)
 	return !strings.Contains(err.Error(), DiscontinuousBlockError)
 }
 


### PR DESCRIPTION
## Summary
- remove temporary dual-geth switch path introduced for zk->mpt migration (`L2Next` config/flags, runtime switch logic, and `eth_config` migration metadata fetch)
- remove fork-boundary-only batch forcing logic in node batching (`forceBatchPointForJadeFork`) now that migration is complete
- remove derivation transition-only root validation bypass and clean related migration-specific logging/messages

## Test plan
- [x] `cd node && go build ./...`
- [x] verify touched files have no lint diagnostics in Cursor
- [ ] run integration/e2e regression in CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy fork-specific batching and related state handling.
  * Removed multi-endpoint upgrade-switch support and associated CLI flags.
  * Simplified startup to use a single L2 endpoint and reduced client initialization steps.
  * Consolidated retry/client logic to a single consistent RPC path.
  * Clarified and toned down node sync/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->