### PR TITLE
feat(node): multi-blob derivation support (V2 batch)

### DIFF
--- a/node/derivation/batch_info.go
+++ b/node/derivation/batch_info.go
@@ -1,10 +1,8 @@
 package derivation
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"math/big"
 
 	"github.com/morph-l2/go-ethereum/common"
@@ -98,8 +96,27 @@ func (bi *BatchInfo) ParseBatch(batch geth.RPCRollupBatch) error {
 	bi.withdrawalRoot = batch.WithdrawRoot
 	bi.version = uint64(batch.Version)
 	tq := newTxQueue()
-	var rawBlockContexts hexutil.Bytes
-	var txsData []byte
+
+	// Multi-blob batches (V2+) are produced by zstd-compressing the entire
+	// batch payload as a single stream and then splitting the compressed
+	// bytes across N blobs in submission order. To recover the payload we
+	// must concatenate all blob bodies first and decompress once; per-blob
+	// decompression would fail on the second blob since it is not a
+	// standalone zstd stream.
+	compressed := make([]byte, 0, len(batch.Sidecar.Blobs)*types.MaxBlobBytesSize)
+	for i := range batch.Sidecar.Blobs {
+		blobCopy := batch.Sidecar.Blobs[i]
+		blobData, err := types.RetrieveBlobBytes(&blobCopy)
+		if err != nil {
+			return err
+		}
+		compressed = append(compressed, blobData...)
+	}
+	batchBytes, err := zstd.DecompressBatchBytes(compressed)
+	if err != nil {
+		return fmt.Errorf("decompress batch bytes error:%v", err)
+	}
+
 	var blockCount uint64
 	if batch.Version > 0 {
 		parentVersion, err := parentBatchHeader.Version()
@@ -107,13 +124,11 @@ func (bi *BatchInfo) ParseBatch(batch geth.RPCRollupBatch) error {
 			return fmt.Errorf("decode batch header version error:%v", err)
 		}
 		if parentVersion == 0 {
-			blobData, err := types.RetrieveBlobBytes(&batch.Sidecar.Blobs[0])
-			if err != nil {
-				return err
-			}
-			batchBytes, err := zstd.DecompressBatchBytes(blobData)
-			if err != nil {
-				return fmt.Errorf("decompress batch bytes error:%v", err)
+			// V0 -> V1+ transition: parent header carries no LastBlockNumber,
+			// so derive blockCount from the first block context embedded at
+			// the start of the decompressed batch.
+			if len(batchBytes) < 60 {
+				return fmt.Errorf("decompressed batch too short for start block context: have %d, need 60", len(batchBytes))
 			}
 			var startBlock BlockContext
 			if err := startBlock.Decode(batchBytes[:60]); err != nil {
@@ -127,47 +142,30 @@ func (bi *BatchInfo) ParseBatch(batch geth.RPCRollupBatch) error {
 			}
 			blockCount = batch.LastBlockNumber - parentBatchBlock
 		}
+	}
 
-	}
-	// If BlockContexts is not nil, the block context should not be included in the blob.
-	// Therefore, the required length must be zero.
-	length := blockCount * 60
-	for _, blob := range batch.Sidecar.Blobs {
-		blobCopy := blob
-		blobData, err := types.RetrieveBlobBytes(&blobCopy)
-		if err != nil {
-			return err
-		}
-		batchBytes, err := zstd.DecompressBatchBytes(blobData)
-		if err != nil {
-			return err
-		}
-		reader := bytes.NewReader(batchBytes)
-		if batch.BlockContexts == nil {
-			if len(batchBytes) < int(length) {
-				rawBlockContexts = append(rawBlockContexts, batchBytes...)
-				length -= uint64(len(batchBytes))
-				reader.Reset(nil)
-			} else {
-				bcBytes := make([]byte, length)
-				_, err = reader.Read(bcBytes)
-				if err != nil {
-					return fmt.Errorf("read block context error:%s", err.Error())
-				}
-				rawBlockContexts = append(rawBlockContexts, bcBytes...)
-				length = 0
-			}
-		}
-		data, err := io.ReadAll(reader)
-		if err != nil {
-			return fmt.Errorf("read txBytes error:%s", err.Error())
-		}
-		txsData = append(txsData, data...)
-	}
+	var rawBlockContexts hexutil.Bytes
+	var txsData []byte
 	if batch.BlockContexts != nil {
+		// Block contexts come from calldata; the entire decompressed stream
+		// is tx payload data.
 		blockCount = uint64(binary.BigEndian.Uint16(batch.BlockContexts[:2]))
+		if uint64(len(batch.BlockContexts)) < 2+60*blockCount {
+			return fmt.Errorf("calldata block contexts too short: have %d, need %d", len(batch.BlockContexts), 2+60*blockCount)
+		}
 		rawBlockContexts = batch.BlockContexts[2 : 60*blockCount+2]
+		txsData = batchBytes
+	} else {
+		// Block contexts are at the head of the decompressed stream,
+		// immediately followed by the tx payload bytes.
+		bcLen := blockCount * 60
+		if uint64(len(batchBytes)) < bcLen {
+			return fmt.Errorf("decompressed batch too short for block contexts: have %d, need %d", len(batchBytes), bcLen)
+		}
+		rawBlockContexts = batchBytes[:bcLen]
+		txsData = batchBytes[bcLen:]
 	}
+
 	data, err := types.DecodeTxsFromBytes(txsData)
 	if err != nil {
 		return err

--- a/node/derivation/batch_info_test.go
+++ b/node/derivation/batch_info_test.go
@@ -1,0 +1,224 @@
+package derivation
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
+	eth "github.com/morph-l2/go-ethereum/core/types"
+	geth "github.com/morph-l2/go-ethereum/eth"
+	"github.com/stretchr/testify/require"
+
+	"morph-l2/node/types"
+	"morph-l2/node/zstd"
+)
+
+// buildBlockContexts returns the concatenated 60-byte encoding of `count`
+// sequential, tx-empty blocks starting at `startBlock`. The produced layout
+// matches what tx-submitter places at the head of a V1/V2 batch payload.
+func buildBlockContexts(startBlock uint64, count int) []byte {
+	buf := make([]byte, 0, count*60)
+	for i := 0; i < count; i++ {
+		wb := &types.WrappedBlock{
+			Number:    startBlock + uint64(i),
+			Timestamp: 1_700_000_000 + uint64(i)*6,
+			BaseFee:   big.NewInt(1_000_000_000),
+			GasLimit:  30_000_000,
+		}
+		buf = append(buf, wb.BlockContextBytes(0, 0)...)
+	}
+	return buf
+}
+
+// buildV1ParentHeader encodes a minimal V1 parent header whose LastBlockNumber
+// is one below `nextStartBlock`, so that ParseBatch can derive blockCount via
+// the (batch.LastBlockNumber - parent.LastBlockNumber) path.
+func buildV1ParentHeader(parentIndex, nextStartBlock uint64) []byte {
+	return types.BatchHeaderV1{
+		BatchHeaderV0: types.BatchHeaderV0{
+			BatchIndex:        parentIndex,
+			BlobVersionedHash: types.EmptyVersionedHash,
+		},
+		LastBlockNumber: nextStartBlock - 1,
+	}.Bytes()
+}
+
+// splitCompressedIntoBlobs mirrors the tx-submitter strategy of compressing
+// the entire payload as a single zstd stream and then slicing the compressed
+// bytes into MaxBlobBytesSize chunks, each packed into a canonical blob.
+func splitCompressedIntoBlobs(t *testing.T, compressed []byte) []kzg4844.Blob {
+	t.Helper()
+	var blobs []kzg4844.Blob
+	for offset := 0; offset < len(compressed); offset += types.MaxBlobBytesSize {
+		end := offset + types.MaxBlobBytesSize
+		if end > len(compressed) {
+			end = len(compressed)
+		}
+		blob, err := types.MakeBlobCanonical(compressed[offset:end])
+		require.NoError(t, err)
+		blobs = append(blobs, *blob)
+	}
+	if len(blobs) == 0 {
+		// An empty payload still requires at least one (empty) blob so that
+		// downstream consumers can iterate. Production submitters never emit
+		// an empty batch, but the helper should remain total.
+		blobs = append(blobs, kzg4844.Blob{})
+	}
+	return blobs
+}
+
+// TestParseBatchSingleBlob covers the backward-compatible path where a V1
+// batch fits in a single blob. It guards against regressions in the recent
+// "concatenate then decompress" refactor: the single-blob flow must still
+// yield the same block contexts it did before multi-blob support landed.
+func TestParseBatchSingleBlob(t *testing.T) {
+	const (
+		parentIndex = 99
+		startBlock  = 1_000
+		blockCount  = 5
+	)
+
+	blockCtx := buildBlockContexts(startBlock, blockCount)
+	payload := append(blockCtx, 0x00) // empty tx stream terminator
+
+	compressed, err := zstd.CompressBatchBytes(payload)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(compressed), types.MaxBlobBytesSize,
+		"single-blob test expects compressed payload to fit in one blob")
+
+	blobs := splitCompressedIntoBlobs(t, compressed)
+	require.Len(t, blobs, 1)
+
+	batch := geth.RPCRollupBatch{
+		Version:           1,
+		ParentBatchHeader: buildV1ParentHeader(parentIndex, startBlock),
+		LastBlockNumber:   startBlock + blockCount - 1,
+		Sidecar:           eth.BlobTxSidecar{Blobs: blobs},
+	}
+
+	var bi BatchInfo
+	require.NoError(t, bi.ParseBatch(batch))
+
+	require.EqualValues(t, parentIndex+1, bi.batchIndex)
+	require.EqualValues(t, startBlock, bi.FirstBlockNumber())
+	require.EqualValues(t, startBlock+blockCount-1, bi.LastBlockNumber())
+	require.Len(t, bi.blockContexts, blockCount)
+	for i, bc := range bi.blockContexts {
+		require.EqualValues(t, uint64(startBlock+i), bc.Number,
+			"block %d number mismatch", i)
+	}
+}
+
+// TestParseBatchMultiBlob is the core multi-blob regression: it forces the
+// compressed payload to exceed a single blob's capacity and verifies that
+// ParseBatch reconstructs the decompressed stream by concatenating all blob
+// bodies before running zstd.Decompress. A naive per-blob decompression loop
+// would fail on blob[1] since it is mid-zstd-frame data, so a successful
+// parse here proves the concatenation path is wired correctly.
+//
+// Compression-resistant random bytes are appended after the block-context
+// header (past the tx terminator) purely to inflate the compressed size; the
+// tx decoder stops at the first 0x00 byte and trailing random bytes are never
+// interpreted as transactions.
+func TestParseBatchMultiBlob(t *testing.T) {
+	const (
+		parentIndex = 123
+		startBlock  = 2_000
+		blockCount  = 8
+	)
+
+	blockCtx := buildBlockContexts(startBlock, blockCount)
+
+	// 1 byte tx terminator + ~1.2x blob capacity of incompressible noise to
+	// guarantee the zstd output straddles a blob boundary.
+	padLen := types.MaxBlobBytesSize + types.MaxBlobBytesSize/5
+	pad := make([]byte, padLen)
+	_, err := rand.Read(pad)
+	require.NoError(t, err)
+
+	payload := make([]byte, 0, len(blockCtx)+1+padLen)
+	payload = append(payload, blockCtx...)
+	payload = append(payload, 0x00)
+	payload = append(payload, pad...)
+
+	compressed, err := zstd.CompressBatchBytes(payload)
+	require.NoError(t, err)
+	require.Greater(t, len(compressed), types.MaxBlobBytesSize,
+		"multi-blob test requires compressed payload to overflow a single blob")
+
+	blobs := splitCompressedIntoBlobs(t, compressed)
+	require.GreaterOrEqual(t, len(blobs), 2, "expected at least 2 blobs for multi-blob path")
+
+	batch := geth.RPCRollupBatch{
+		Version:           2,
+		ParentBatchHeader: buildV1ParentHeader(parentIndex, startBlock),
+		LastBlockNumber:   startBlock + blockCount - 1,
+		PrevStateRoot:     common.BigToHash(big.NewInt(1)),
+		PostStateRoot:     common.BigToHash(big.NewInt(2)),
+		WithdrawRoot:      common.BigToHash(big.NewInt(3)),
+		Sidecar:           eth.BlobTxSidecar{Blobs: blobs},
+	}
+
+	var bi BatchInfo
+	require.NoError(t, bi.ParseBatch(batch))
+
+	require.EqualValues(t, parentIndex+1, bi.batchIndex)
+	require.EqualValues(t, 2, bi.version)
+	require.EqualValues(t, startBlock, bi.FirstBlockNumber())
+	require.EqualValues(t, startBlock+blockCount-1, bi.LastBlockNumber())
+	require.Len(t, bi.blockContexts, blockCount)
+	for i, bc := range bi.blockContexts {
+		require.EqualValues(t, uint64(startBlock+i), bc.Number,
+			"block %d number mismatch", i)
+		require.EqualValues(t, 1_700_000_000+uint64(i)*6, bc.Timestamp,
+			"block %d timestamp mismatch", i)
+	}
+	require.EqualValues(t, batch.PostStateRoot, bi.root)
+	require.EqualValues(t, batch.WithdrawRoot, bi.withdrawalRoot)
+}
+
+// TestParseBatchMultiBlobConcatDecompressInvariant directly exercises the
+// low-level invariant that multi-blob ParseBatch relies on: the compressed
+// stream can only be recovered by concatenating blob bodies in submission
+// order and decompressing once. Per-blob decompression must fail on any
+// non-initial blob, and reordering blobs must corrupt the decompressed
+// output. Keeping this explicit protects the invariant even if ParseBatch is
+// later refactored to hide the concatenation step.
+func TestParseBatchMultiBlobConcatDecompressInvariant(t *testing.T) {
+	pad := make([]byte, types.MaxBlobBytesSize+types.MaxBlobBytesSize/5)
+	_, err := rand.Read(pad)
+	require.NoError(t, err)
+
+	compressed, err := zstd.CompressBatchBytes(pad)
+	require.NoError(t, err)
+	require.Greater(t, len(compressed), types.MaxBlobBytesSize)
+
+	blobs := splitCompressedIntoBlobs(t, compressed)
+	require.GreaterOrEqual(t, len(blobs), 2)
+
+	// In-order concatenation round-trips.
+	var concat []byte
+	for i := range blobs {
+		body, err := types.RetrieveBlobBytes(&blobs[i])
+		require.NoError(t, err)
+		concat = append(concat, body...)
+	}
+	decoded, err := zstd.DecompressBatchBytes(concat)
+	require.NoError(t, err)
+	require.Equal(t, pad, decoded)
+
+	// Reversing blob order must corrupt the stream; decompression should
+	// either error or yield a different payload.
+	var reversed []byte
+	for i := len(blobs) - 1; i >= 0; i-- {
+		body, err := types.RetrieveBlobBytes(&blobs[i])
+		require.NoError(t, err)
+		reversed = append(reversed, body...)
+	}
+	if out, err := zstd.DecompressBatchBytes(reversed); err == nil {
+		require.NotEqual(t, pad, out,
+			"reversed-blob decompression unexpectedly matched payload")
+	}
+}

--- a/node/derivation/batch_info_test.go
+++ b/node/derivation/batch_info_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/morph-l2/go-ethereum/common"
-	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	eth "github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	geth "github.com/morph-l2/go-ethereum/eth"
 	"github.com/stretchr/testify/require"
 

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -389,49 +389,47 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 			return nil, fmt.Errorf("failed to get blobs, continuing processing:%v", err)
 		}
 		if len(blobSidecars) > 0 {
-			// Create blob sidecar
-			var blobTxSidecar eth.BlobTxSidecar
-			matchedCount := 0
-
-			// Match blobs
+			// Index beacon sidecars by their KZG-derived versioned hash so we
+			// can assemble the local sidecar in the exact order the L1 tx
+			// declared its blobs. Multi-blob batches are decoded by
+			// concatenating blob bodies in tx order; any reordering here
+			// would corrupt the resulting zstd stream.
+			byHash := make(map[common.Hash]*BlobSidecar, len(blobSidecars))
 			for _, sidecar := range blobSidecars {
 				var commitment kzg4844.Commitment
 				copy(commitment[:], sidecar.KZGCommitment[:])
 				versionedHash := KZGToVersionedHash(commitment)
+				byHash[versionedHash] = sidecar
+			}
 
-				for _, expectedHash := range blobHashes {
-					if bytes.Equal(versionedHash[:], expectedHash[:]) {
-						matchedCount++
-						d.logger.Info("Found matching blob", "index", sidecar.Index, "hash", versionedHash.Hex())
-
-						// Decode and process blob data
-						var blob Blob
-						b, err := hexutil.Decode(sidecar.Blob)
-						if err != nil {
-							d.logger.Error("Failed to decode blob data", "error", err)
-							continue
-						}
-						copy(blob[:], b)
-
-						// Verify blob
-						//if err := VerifyBlobProof(&blob, commitment, kzg4844.Proof(sidecar.KZGProof)); err != nil {
-						//	d.logger.Error("Blob verification failed", "error", err)
-						//	continue
-						//}
-
-						// Add to sidecar
-						blobTxSidecar.Blobs = append(blobTxSidecar.Blobs, *blob.KZGBlob())
-						blobTxSidecar.Commitments = append(blobTxSidecar.Commitments, commitment)
-						blobTxSidecar.Proofs = append(blobTxSidecar.Proofs, kzg4844.Proof(sidecar.KZGProof))
-						break
-					}
+			var blobTxSidecar eth.BlobTxSidecar
+			for i, expectedHash := range blobHashes {
+				sidecar, ok := byHash[expectedHash]
+				if !ok {
+					return nil, fmt.Errorf("blob %d (hash=%s) not found in beacon sidecars", i, expectedHash.Hex())
 				}
+				var commitment kzg4844.Commitment
+				copy(commitment[:], sidecar.KZGCommitment[:])
+
+				var blob Blob
+				b, err := hexutil.Decode(sidecar.Blob)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode blob %d: %w", i, err)
+				}
+				copy(blob[:], b)
+
+				proof := kzg4844.Proof(sidecar.KZGProof)
+				if err := VerifyBlobProof(&blob, commitment, proof); err != nil {
+					return nil, fmt.Errorf("blob %d KZG proof verification failed: %w", i, err)
+				}
+
+				d.logger.Info("Matched blob", "txOrder", i, "beaconIndex", sidecar.Index, "hash", expectedHash.Hex())
+				blobTxSidecar.Blobs = append(blobTxSidecar.Blobs, *blob.KZGBlob())
+				blobTxSidecar.Commitments = append(blobTxSidecar.Commitments, commitment)
+				blobTxSidecar.Proofs = append(blobTxSidecar.Proofs, proof)
 			}
 
-			d.logger.Info("Blob matching results", "matched", matchedCount, "expected", len(blobHashes))
-			if matchedCount == 0 {
-				return nil, fmt.Errorf("no matching versionedHash was found")
-			}
+			d.logger.Info("Blob matching results", "matched", len(blobTxSidecar.Blobs), "expected", len(blobHashes))
 			batch.Sidecar = blobTxSidecar
 		} else {
 			return nil, fmt.Errorf("not matched blob,txHash:%v,blockNumber:%v", txHash, blockNumber)

--- a/node/types/batch_header.go
+++ b/node/types/batch_header.go
@@ -16,9 +16,15 @@ type (
 const (
 	expectedLengthV0 = 249
 	expectedLengthV1 = 257
+	// V2 reuses the V1 wire format (257 bytes). The only semantic
+	// difference is that the 32-byte field at offset 57 stores
+	// keccak256(blobhash(0) || ... || blobhash(N-1)) instead of a
+	// single blob versioned hash.
+	expectedLengthV2 = 257
 
 	BatchHeaderVersion0 = 0
 	BatchHeaderVersion1 = 1
+	BatchHeaderVersion2 = 2
 )
 
 var (
@@ -40,6 +46,10 @@ func (b BatchHeaderBytes) validate() error {
 		}
 	case BatchHeaderVersion1:
 		if len(b) != expectedLengthV1 {
+			return ErrInvalidBatchHeaderLength
+		}
+	case BatchHeaderVersion2:
+		if len(b) != expectedLengthV2 {
 			return ErrInvalidBatchHeaderLength
 		}
 	default:
@@ -94,9 +104,31 @@ func (b BatchHeaderBytes) DataHash() (common.Hash, error) {
 	return common.BytesToHash(b[25:57]), nil
 }
 
+// BlobVersionedHash returns the EIP-4844 blob versioned hash recorded at
+// offset [57:89]. This is only meaningful for V0/V1 batches, where the field
+// holds the single blob's versioned hash. For V2 batches the same offset
+// holds an aggregated hash; callers must use BlobHashesHash instead.
 func (b BatchHeaderBytes) BlobVersionedHash() (common.Hash, error) {
 	if err := b.validate(); err != nil {
 		return common.Hash{}, err
+	}
+	version, _ := b.Version()
+	if version >= BatchHeaderVersion2 {
+		return common.Hash{}, errors.New("BlobVersionedHash is not available for V2+; use BlobHashesHash")
+	}
+	return common.BytesToHash(b[57:89]), nil
+}
+
+// BlobHashesHash returns the aggregated blob hash recorded at offset [57:89]
+// for V2+ batches, defined as keccak256(blobhash(0) || ... || blobhash(N-1)).
+// V0/V1 batches do not aggregate and will return an error.
+func (b BatchHeaderBytes) BlobHashesHash() (common.Hash, error) {
+	if err := b.validate(); err != nil {
+		return common.Hash{}, err
+	}
+	version, _ := b.Version()
+	if version < BatchHeaderVersion2 {
+		return common.Hash{}, errors.New("BlobHashesHash is only available for V2+; use BlobVersionedHash")
 	}
 	return common.BytesToHash(b[57:89]), nil
 }

--- a/node/types/batch_test.go
+++ b/node/types/batch_test.go
@@ -71,6 +71,83 @@ func TestBatchHeader(t *testing.T) {
 	require.EqualValues(t, 1000, lastBlockNumber)
 }
 
+// TestBatchHeaderV2 exercises the V2 header variant: it reuses the V1 wire
+// layout (257 bytes) but the 32-byte field at offset 57 carries an aggregated
+// blob hash (keccak256(blobhash(0)||...||blobhash(N-1))) rather than a single
+// versioned hash. Parsing helpers must route callers accordingly.
+func TestBatchHeaderV2(t *testing.T) {
+	aggregated := common.BigToHash(big.NewInt(0xABCDEF))
+
+	// Start from a V1 encoding (identical byte layout), then flip the version
+	// byte to V2. This matches the on-chain behaviour where a V2 header is
+	// produced by tx-submitter with the aggregated hash stored at offset 57.
+	raw := BatchHeaderV1{
+		BatchHeaderV0: BatchHeaderV0{
+			BatchIndex:             42,
+			L1MessagePopped:        1,
+			TotalL1MessagePopped:   3,
+			DataHash:               common.BigToHash(big.NewInt(0x11)),
+			BlobVersionedHash:      aggregated,
+			PrevStateRoot:          common.BigToHash(big.NewInt(0x22)),
+			PostStateRoot:          common.BigToHash(big.NewInt(0x33)),
+			WithdrawalRoot:         common.BigToHash(big.NewInt(0x44)),
+			SequencerSetVerifyHash: common.BigToHash(big.NewInt(0x55)),
+			ParentBatchHash:        common.BigToHash(big.NewInt(0x66)),
+		},
+		LastBlockNumber: 9_876,
+	}.Bytes()
+	raw[0] = BatchHeaderVersion2
+
+	version, err := raw.Version()
+	require.NoError(t, err)
+	require.EqualValues(t, BatchHeaderVersion2, version)
+
+	batchIndex, err := raw.BatchIndex()
+	require.NoError(t, err)
+	require.EqualValues(t, 42, batchIndex)
+
+	lastBlockNumber, err := raw.LastBlockNumber()
+	require.NoError(t, err)
+	require.EqualValues(t, 9_876, lastBlockNumber)
+
+	// V2 headers must route callers to BlobHashesHash; the legacy accessor
+	// intentionally errors to prevent silent mis-use.
+	_, err = raw.BlobVersionedHash()
+	require.Error(t, err)
+
+	aggHash, err := raw.BlobHashesHash()
+	require.NoError(t, err)
+	require.EqualValues(t, aggregated, aggHash)
+
+	// Length check: a V2 header with the wrong length must fail validate().
+	short := make(BatchHeaderBytes, expectedLengthV2-1)
+	short[0] = BatchHeaderVersion2
+	_, err = short.BatchIndex()
+	require.ErrorIs(t, err, ErrInvalidBatchHeaderLength)
+}
+
+// TestBlobHashesHashUnavailableForLegacy guards the inverse direction: V0 and
+// V1 headers must reject BlobHashesHash so that callers reach for the correct
+// accessor.
+func TestBlobHashesHashUnavailableForLegacy(t *testing.T) {
+	v0 := BatchHeaderV0{
+		BatchIndex:        1,
+		BlobVersionedHash: EmptyVersionedHash,
+	}.Bytes()
+	_, err := v0.BlobHashesHash()
+	require.Error(t, err)
+
+	v1 := BatchHeaderV1{
+		BatchHeaderV0: BatchHeaderV0{
+			BatchIndex:        2,
+			BlobVersionedHash: EmptyVersionedHash,
+		},
+		LastBlockNumber: 10,
+	}.Bytes()
+	_, err = v1.BlobHashesHash()
+	require.Error(t, err)
+}
+
 func TestMethodID(t *testing.T) {
 	beforeSkipABI, err := LegacyRollupMetaData.GetAbi()
 	require.NoError(t, err)

--- a/node/types/batch_test.go
+++ b/node/types/batch_test.go
@@ -79,7 +79,7 @@ func TestBatchHeaderV2(t *testing.T) {
 	aggregated := common.BigToHash(big.NewInt(0xABCDEF))
 
 	// Start from a V1 encoding (identical byte layout), then flip the version
-	// byte to V2. This matches the on-chain behaviour where a V2 header is
+	// byte to V2. This matches the on-chain behavior where a V2 header is
 	// produced by tx-submitter with the aggregated hash stored at offset 57.
 	raw := BatchHeaderV1{
 		BatchHeaderV0: BatchHeaderV0{

--- a/tx-submitter/batch/batch_header.go
+++ b/tx-submitter/batch/batch_header.go
@@ -218,4 +218,3 @@ func (b BatchHeaderV1) Bytes() BatchHeaderBytes {
 	b.EncodedBytes = batchBytes
 	return batchBytes
 }
-


### PR DESCRIPTION
## Summary

Complete the last remaining piece on `feat/multi_batch`: **node-side derivation support for V2 multi-blob batches**. V2 support on the contracts / prover / challenger sides has already landed on `feat/multi_batch`; this PR fills in the derivation gap so that multi-blob batches can be decoded end-to-end.

Key design points (aligned with `morph-specs` spec-002 §3.2 step 7 and §4.2.5):

- **Concat first, decompress once.** tx-submitter for V2 compresses the entire `batchBytes` as a single zstd stream and then splits it across blobs by `MaxBlobBytesSize`. Only blob[0] carries a valid zstd frame header; blob[1..N-1] are middle bytes. The previous implementation decompressed each blob independently and appended the results, which fails as soon as more than one blob is used. The new path iterates blobs in `tx.BlobHashes()` order, extracts raw scalar bytes, concatenates into a single buffer, and calls `zstd.DecompressBatchBytes` exactly once.

- **Strict reordering against `tx.BlobHashes()`.** The Beacon API does not guarantee sidecar order matches the L1 tx's declared blob hashes. Any reordering would corrupt the concatenated zstd stream. We index sidecars by the KZG-derived versioned hash and reassemble the local `BlobTxSidecar` in exactly the order declared by the tx.

- **Per-blob `VerifyBlobProof`.** KZG proof verification runs per blob before concatenation. A corrupt blob is located directly instead of being misattributed to a decompression failure downstream.

- **V2 header parsing.** V2 reuses V1's 257-byte wire layout, but the semantics of offset 57 change from "single versioned hash" to "aggregated hash `keccak(hash[0]||...||hash[N-1])`".
  - `BlobVersionedHash()` returns an error on V2+ to prevent callers from silently treating the aggregated hash as a single blob hash.
  - New `BlobHashesHash()` accessor returns the aggregated hash; it errors on V0/V1.

## Changes

### `node/types/batch_header.go`
- Add `BatchHeaderVersion2 = 2` and `expectedLengthV2 = 257`.
- `validate()` accepts the V2 length.
- Split `BlobVersionedHash()` (V0/V1 only) and `BlobHashesHash()` (V2+ only), each guarded by a version check.

### `node/derivation/batch_info.go`
- Rewrite `ParseBatch()` to concatenate all blob raw bytes in tx order first, then perform a single `DecompressBatchBytes`.

### `node/derivation/derivation.go`
- `fetchRollupDataByTxHash()` reorders beacon sidecars by `tx.BlobHashes()` via a KZG-derived hash index.
- Enable per-blob `VerifyBlobProof`.

## Tests

```
node/types:
  TestBatchHeader                                    PASS
  TestBatchHeaderV2                                  PASS
  TestBlobHashesHashUnavailableForLegacy             PASS

node/derivation:
  TestParseBatchSingleBlob                           PASS
  TestParseBatchMultiBlob                            PASS  (random incompressible payload forces compressed size > MaxBlobBytesSize, guaranteeing split across 2 blobs)
  TestParseBatchMultiBlobConcatDecompressInvariant   PASS
```

## Test Plan

- [x] `go build ./...` passes.
- [x] Unit tests: single-blob regression + multi-blob cross-boundary parsing + V2 header parsing + V0/V1 guards.
- [ ] (integration) Devnet end-to-end V2 multi-blob run: tx-submitter emits a multi-blob batch → rollup `commitBatch` → node derivation → state replay.
- [ ] (integration) V1 parent → V2 child transition batch: verify `blockCount` derivation is correct across the version bump.

## Related

- Spec: `morph-l2/morph-specs/specs/2026/Q2/spec-002-multi-blob-batch-submission`
- Base branch commits: V2 contracts (`d78251c4` / `56bd83ff` / `9ae6e516`), prover multi-blob (`2711f073` / `9894b040` / `edf823ff`), challenger (`8c419a78`).