### PR TITLE
[codex] Fix devnet Docker submitter config

### DIFF
--- a/ops/docker/docker-compose-4nodes.yml
+++ b/ops/docker/docker-compose-4nodes.yml
@@ -403,7 +403,7 @@ services:
        - "7546:8546"
        - "7551:8551"
      healthcheck:
-       test: curl -f http://localhost:8545
+       test: ["CMD-SHELL", "wget -qO- --header='Content-Type: application/json' --post-data='{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' http://localhost:8545 | grep -q '\"result\"'"]
        interval: 30s
        timeout: 5s
        retries: 3
@@ -483,6 +483,7 @@ services:
      - TX_SUBMITTER_FINALIZE=true
      - TX_SUBMITTER_MAX_FINALIZE_NUM=100
      - TX_SUBMITTER_PRIORITY_ROLLUP=false
+     - TX_SUBMITTER_SEAL_BATCH=true
      - TX_SUBMITTER_METRICS_SERVER_ENABLE=false
      - TX_SUBMITTER_METRICS_HOSTNAME=0.0.0.0
      - TX_SUBMITTER_METRICS_PORT=6060
@@ -525,6 +526,7 @@ services:
      - TX_SUBMITTER_FINALIZE=false
      - TX_SUBMITTER_MAX_FINALIZE_NUM=100
      - TX_SUBMITTER_PRIORITY_ROLLUP=false
+     - TX_SUBMITTER_SEAL_BATCH=true
      - TX_SUBMITTER_METRICS_SERVER_ENABLE=false
      - TX_SUBMITTER_METRICS_HOSTNAME=0.0.0.0
      - TX_SUBMITTER_METRICS_PORT=6060
@@ -567,6 +569,7 @@ services:
       - TX_SUBMITTER_FINALIZE=false
       - TX_SUBMITTER_MAX_FINALIZE_NUM=100
       - TX_SUBMITTER_PRIORITY_ROLLUP=false
+      - TX_SUBMITTER_SEAL_BATCH=true
       - TX_SUBMITTER_METRICS_SERVER_ENABLE=false
       - TX_SUBMITTER_METRICS_HOSTNAME=0.0.0.0
       - TX_SUBMITTER_METRICS_PORT=6060
@@ -609,6 +612,7 @@ services:
       - TX_SUBMITTER_FINALIZE=false
       - TX_SUBMITTER_MAX_FINALIZE_NUM=100
       - TX_SUBMITTER_PRIORITY_ROLLUP=false
+      - TX_SUBMITTER_SEAL_BATCH=true
       - TX_SUBMITTER_METRICS_SERVER_ENABLE=false
       - TX_SUBMITTER_METRICS_HOSTNAME=0.0.0.0
       - TX_SUBMITTER_METRICS_PORT=6060


### PR DESCRIPTION
## Summary
- Enable batch sealing for all devnet tx-submitters so batches are generated locally.
- Replace validator_geth curl healthcheck with a wget JSON-RPC probe available in the image.

## Validation
- `docker compose -f ops/docker/docker-compose-4nodes.yml config`
- `git diff --check -- ops/docker/docker-compose-4nodes.yml`
- Recreated devnet submitters and validator_geth locally; observed validator_geth healthy and validator batch index advancing.

## Notes
- Leaves go.work unchanged so Docker builds continue fetching modules normally.