### PR TITLE
fix(prover): replace .unwrap() with map_err in blob KZG verification

### DIFF
--- a/prover/crates/executor/client/src/verifier/blob_verifier.rs
+++ b/prover/crates/executor/client/src/verifier/blob_verifier.rs
@@ -45,9 +45,12 @@ impl BlobVerifier {
     /// KZG-verify a blob's commitment/proof and return its versioned hash.
     fn verify_kzg(blob_info: &BlobInfo) -> Result<B256, anyhow::Error> {
         let versioned_hash = kzg_to_versioned_hash(&blob_info.commitment);
-        let blob = KzgRsBlob::from_slice(&blob_info.blob_data).unwrap();
-        let commitment = Bytes48::from_slice(&blob_info.commitment).unwrap();
-        let proof = Bytes48::from_slice(&blob_info.proof).unwrap();
+        let blob = KzgRsBlob::from_slice(&blob_info.blob_data)
+            .map_err(|e| anyhow!("invalid blob_data length: {e:?}"))?;
+        let commitment = Bytes48::from_slice(&blob_info.commitment)
+            .map_err(|e| anyhow!("invalid commitment length: {e:?}"))?;
+        let proof = Bytes48::from_slice(&blob_info.proof)
+            .map_err(|e| anyhow!("invalid proof length: {e:?}"))?;
 
         let verify_result =
             kzg_rs::KzgProof::verify_blob_kzg_proof(blob, &commitment, &proof, &get_kzg_settings())


### PR DESCRIPTION
## Summary
- The three `.unwrap()` calls in `BlobVerifier::verify_kzg` (on `KzgRsBlob::from_slice` / `Bytes48::from_slice`) could panic the prover process if the upstream RPC returned malformed blob data, dropping every queued proof along with it.
- Convert each to `.map_err(|e| anyhow!(...))?` so the current request fails cleanly while the process keeps serving other proofs.
- Addresses audit finding **INFO-3** from the 2026-05-15 multi-blob audit (PR #935).

## Test plan
- [x] `cargo check -p prover-executor-client`
- [x] Existing prover unit/integration tests pass in CI