### PR TITLE
docs(prover): explain why header.state_root replaces morph_diskRoot

### DIFF
--- a/prover/crates/executor/host/src/execute.rs
+++ b/prover/crates/executor/host/src/execute.rs
@@ -29,6 +29,9 @@ impl HostExecutor {
         let block = query_block(block_number, provider)
             .await
             .with_context(|| format!("query_block failed for block {block_number}"))?;
+        // Post-MPT migration (PR #886), the L2 state trie is a standard Ethereum MPT, so
+        // `header.state_root` is authoritative and replaces the previous custom `morph_diskRoot`
+        // RPC field. The root is re-derived locally below and checked against this value.
         let post_state_root = block.header.state_root;
 
         // layer2 chain id
@@ -49,6 +52,7 @@ impl HostExecutor {
         let prev_block = query_block(prev_block_number, provider)
             .await
             .with_context(|| format!("query_block failed for prev block {prev_block_number}"))?;
+        // Same rationale as `post_state_root`: header state_root is the MPT root.
         let prev_state_root = prev_block.header.state_root;
 
         let tx_count = block.transactions.len();


### PR DESCRIPTION
## Summary
- The host executor was migrated from the custom `morph_diskRoot` RPC field to the standard `block.header.state_root` in commit e0756a4b, but the rationale was not captured in the code.
- After the zkTrie → MPT migration (PR #886) the header state_root is the authoritative MPT root, so the custom field became redundant.
- Add a short comment at both `post_state_root` and `prev_state_root` so future readers don't need to dig through git history to understand the equivalence.
- Addresses audit finding **INFO-1** from the 2026-05-15 multi-blob audit (PR #935).

## Test plan
- [x] `cargo check -p prover-executor-host`
- Comment-only change; no behavior modified.