### PR TITLE
docs(shadow-prove): clarify version is read for logging only in calc_batch_pi

### DIFF
--- a/prover/bin/shadow-prove/src/shadow_rollup.rs
+++ b/prover/bin/shadow-prove/src/shadow_rollup.rs
@@ -447,6 +447,12 @@ where
         chain_id: u64,
         batch_header: &Bytes,
     ) -> Result<B256, anyhow::Error> {
+        // `version` is read only for logging here. Unlike the V2/non-V2 split in `lib.rs`
+        // (where the prover dispatches different blob-decoding paths), the public-input
+        // formula is uniform across versions: offset 57 holds the blob input field
+        // (versioned hash for V0/V1, aggregated hash for V2), and the on-chain verifier
+        // uses the same layout. Versioned routing happens earlier via the `batch_version`
+        // request parameter; nothing in this function needs to branch on it.
         let version = batch_header.first().copied().unwrap_or(0);
 
         let prev_state_root: &[u8] = batch_header.get(89..121).unwrap_or_default();


### PR DESCRIPTION
## Summary
- `shadow_rollup::calc_batch_pi` extracts `version` from the batch header but never branches on it, which looks inconsistent with the V2/non-V2 split in `lib.rs` and could be mistaken for a missing dispatch.
- The public-input formula is in fact uniform across versions: offset 57 holds the blob input field (versioned hash for V0/V1, aggregated hash for V2) and the on-chain verifier uses the same layout. Version-dependent routing happens earlier via the `batch_version` request parameter.
- Add a comment so maintainers don't need to reverse-engineer this from the header layout.
- Addresses audit finding **INFO-2** from the 2026-05-15 multi-blob audit (PR #935).

## Test plan
- [x] `cargo check -p shadow-proving`
- Comment-only change; no behavior modified.