### PR TITLE
fix(prover): accept reth L1 message tx fields

### DIFF
--- a/prover/crates/primitives/src/types/tx.rs
+++ b/prover/crates/primitives/src/types/tx.rs
@@ -16,12 +16,13 @@ fn default_chain_id() -> U64 {
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct TransactionTrace {
     /// tx hash
-    #[serde(default, rename = "txHash")]
+    #[serde(default, rename = "txHash", alias = "hash")]
     pub(crate) tx_hash: B256,
     /// tx type (in raw from)
     #[serde(rename = "type")]
     pub(crate) ty: U8,
     /// nonce
+    #[serde(default)]
     pub(crate) nonce: U64,
     /// gas limit
     pub(crate) gas: U64,
@@ -81,10 +82,13 @@ pub struct TransactionTrace {
     #[serde(default)]
     pub(crate) memo: Option<Bytes>,
     /// signature v
+    #[serde(default)]
     pub(crate) v: U64,
     /// signature r
+    #[serde(default)]
     pub(crate) r: U256,
     /// signature s
+    #[serde(default)]
     pub(crate) s: U256,
 }
 
@@ -183,5 +187,41 @@ impl TxTrace for TransactionTrace {
 
     fn morph_tx_memo(&self) -> Option<Bytes> {
         self.memo.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TxTrace;
+
+    #[test]
+    fn deserializes_reth_l1_message_transaction_without_signature_fields() {
+        let tx: TransactionTrace = serde_json::from_value(serde_json::json!({
+            "type": "0x7e",
+            "queueIndex": "0x7",
+            "gas": "0x1e8480",
+            "to": "0x5300000000000000000000000000000000000007",
+            "value": "0x0",
+            "sender": "0xed82366effa760804dcfc3edf87fa2a6f1624415",
+            "from": "0xed82366effa760804dcfc3edf87fa2a6f1624415",
+            "input": "0x8ef1332e",
+            "hash": "0x4c03b51e272570d42b0135d48ac612ef59c670e5759df97971be35b93c6310f9",
+            "gasPrice": "0x0",
+            "blockHash": "0x713e0613ab0c3d330707be3006ddffe15a8b2813b0190b985241f7c992fbb57c",
+            "blockNumber": "0xd1",
+            "blockTimestamp": "0x6715f162",
+            "transactionIndex": "0x0"
+        }))
+        .expect("reth L1 message transaction should deserialize");
+
+        assert_eq!(tx.ty(), 0x7e);
+        assert_eq!(tx.queue_index(), Some(7));
+        assert_eq!(
+            tx.tx_hash(),
+            "0x4c03b51e272570d42b0135d48ac612ef59c670e5759df97971be35b93c6310f9"
+                .parse::<B256>()
+                .unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Allow transaction trace deserialization to accept reth-style `hash` for transaction hashes while preserving existing `txHash` output.
- Default missing `nonce`, `v`, `r`, and `s` fields so reth `0x7e` L1 message transactions can be parsed.
- Add a regression test for reth-style L1 message RPC transaction JSON.

## Test plan
- `cargo test -p prover-primitives --lib`
- `DEVNET=true SHOULD_THROTTLE_REQUESTS=false RUST_BACKTRACE=1 cargo test -p morph-prove --lib -- execute::tests::test_execute_local_traces --exact --nocapture`
- `DEVNET=true SHOULD_THROTTLE_REQUESTS=false RUST_BACKTRACE=0 cargo test -p morph-prove --lib -- execute::tests::test_execute_range --exact --nocapture -- --start-block 209 --end-block 209 --rpc http://morph-panos-fullnode-test01.bitkeep.tools:8545` now reaches the expected historical proof window error instead of failing to deserialize the L1 message transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction data handling to tolerate missing signature components and transaction fields, with support for multiple field name formats to enhance compatibility with various transaction data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->