### PR TITLE
feat(derivation): skip L1 fill-gap derivation for pre-upgrade blocks

### DIFF
--- a/bindings/go.mod
+++ b/bindings/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require github.com/morph-l2/go-ethereum v1.10.14-0.20251219060125-03910bc750a2
 

--- a/bindings/go.sum
+++ b/bindings/go.sum
@@ -109,8 +109,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/common/go.mod
+++ b/common/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/holiman/uint256 v1.2.4

--- a/common/go.sum
+++ b/common/go.sum
@@ -148,8 +148,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/contracts/go.mod
+++ b/contracts/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/iden3/go-iden3-crypto v0.0.16

--- a/contracts/go.sum
+++ b/contracts/go.sum
@@ -136,8 +136,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -190,7 +190,7 @@ func L2NodeMain(ctx *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("NewRollup error: %v", err)
 		}
-		dvNode, err = derivation.NewDerivationClient(context.Background(), derivationCfg, syncer, store, rollup, l1Client, tmNode, nodeConfig.Logger)
+		dvNode, err = derivation.NewDerivationClient(context.Background(), derivationCfg, syncer, store, rollup, l1Client, tmNode, verifier, nodeConfig.Logger)
 		if err != nil {
 			return fmt.Errorf("new derivation client error: %v", err)
 		}

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"morph-l2/node/l1sequencer"
 	"time"
 
 	"github.com/morph-l2/go-ethereum"
@@ -74,6 +75,8 @@ type Derivation struct {
 
 	tagAdvancer *tagAdvancer
 
+	l1SequencerVerifier *l1sequencer.SequencerVerifier
+
 	stop chan struct{}
 }
 
@@ -87,7 +90,7 @@ type DeployContractBackend interface {
 // NewDerivationClient takes a shared l1Client owned by main.go. See
 // sync.NewSyncer for rationale — every L1-touching component in this
 // process shares one connection pool / retry / metrics surface.
-func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, db Database, rollup *bindings.Rollup, l1Client *ethclient.Client, node *tmnode.Node, logger tmlog.Logger) (*Derivation, error) {
+func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, db Database, rollup *bindings.Rollup, l1Client *ethclient.Client, node *tmnode.Node, verifier *l1sequencer.SequencerVerifier, logger tmlog.Logger) (*Derivation, error) {
 	if l1Client == nil {
 		return nil, errors.New("l1Client cannot be nil")
 	}
@@ -156,6 +159,7 @@ func NewDerivationClient(ctx context.Context, cfg *Config, syncer *sync.Syncer, 
 		metrics:               metrics,
 		l1BeaconClient:        l1BeaconClient,
 		L2ToL1MessagePasser:   msgPasser,
+		l1SequencerVerifier:   verifier,
 	}
 
 	// First-run startHeight default: when DB has no derivation cursor and no
@@ -334,6 +338,22 @@ func (d *Derivation) derivationBlock(ctx context.Context) {
 				return
 			}
 			if lastHdr == nil {
+				// Pre-upgrade (pbft-era) blocks are held by geth but not tracked
+				// at the node layer, so reconstructing them via L1 fill-gap derive
+				// would diverge geth's height from the node's on restart. When such
+				// a block is missing locally we wait for P2P/blocksync to backfill
+				// instead of deriving. VerificationStartHeight() returns MaxUint64
+				// while the verifier history is still empty, so until it loads every
+				// missing block is treated as pre-upgrade and we wait -- the safe
+				// default before the upgrade height is known.
+				if batchInfo.firstBlockNumber < d.l1SequencerVerifier.VerificationStartHeight() {
+					d.logger.Info("local verify: batch firstBlockNumber below verificationStartHeight (pre-upgrade); "+
+						"waiting for P2P backfill instead of L1 derivation",
+						"batchIndex", batchInfo.batchIndex,
+						"firstBlockNumber", batchInfo.firstBlockNumber,
+						"verificationStartHeight", d.l1SequencerVerifier.VerificationStartHeight())
+					return
+				}
 				if l2Grew {
 					// Abort the whole pull (don't advance the L1 cursor) so
 					// the next poll re-fetches this batch's log and re-tries

--- a/node/go.mod
+++ b/node/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3

--- a/node/go.sum
+++ b/node/go.sum
@@ -414,8 +414,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a h1:TeuQHBpIpH2/Z8jX9sZLtB0+4mwLBfKfII7BD/J5XME=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/node/l1sequencer/verifier.go
+++ b/node/l1sequencer/verifier.go
@@ -56,8 +56,27 @@ func NewSequencerVerifier(caller *bindings.L1SequencerCaller, logger tmlog.Logge
 	if err := v.syncHistory(); err != nil {
 		v.logger.Error("Failed to load sequencer history from L1", "err", err)
 	}
+	v.logCurrentState()
 	go v.refreshLoop(ctx)
 	return v
+}
+
+// logCurrentState prints a one-line snapshot of the loaded contract state at
+// startup: the active sequencer and the height from which verification applies.
+// Existing logs list every record but not which one is currently in effect.
+func (c *SequencerVerifier) logCurrentState() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.history) == 0 {
+		c.logger.Info("Sequencer contract state: no records loaded; verification inactive until L1 history is available")
+		return
+	}
+	current := c.history[len(c.history)-1]
+	c.logger.Info("Sequencer contract state loaded",
+		"totalRecords", len(c.history),
+		"verificationStartHeight", c.history[0].StartL2Block,
+		"currentSequencer", current.SequencerAddr.Hex(),
+		"currentSequencerStartHeight", current.StartL2Block)
 }
 
 // Stop terminates the background refresh loop.

--- a/ops/l2-genesis/go.mod
+++ b/ops/l2-genesis/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/holiman/uint256 v1.2.4

--- a/ops/l2-genesis/go.sum
+++ b/ops/l2-genesis/go.sum
@@ -139,8 +139,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/ops/tools/go.mod
+++ b/ops/tools/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/morph-l2/go-ethereum v1.10.14-0.20251219060125-03910bc750a2

--- a/ops/tools/go.sum
+++ b/ops/tools/go.sum
@@ -161,8 +161,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a h1:TeuQHBpIpH2/Z8jX9sZLtB0+4mwLBfKfII7BD/J5XME=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/oracle/go.mod
+++ b/oracle/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/go-kit/kit v0.12.0

--- a/oracle/go.sum
+++ b/oracle/go.sum
@@ -172,8 +172,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/externalsign v0.3.1 h1:UYFDZFB0L85A4rDvuwLNBiGEi0kSmg9AZ2v8Q5O4dQo=
 github.com/morph-l2/externalsign v0.3.1/go.mod h1:b6NJ4GUiiG/gcSJsp3p8ExsIs4ZdphlrVALASnVoGJE=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a h1:TeuQHBpIpH2/Z8jX9sZLtB0+4mwLBfKfII7BD/J5XME=
 github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/token-price-oracle/go.mod
+++ b/token-price-oracle/go.mod
@@ -2,7 +2,7 @@ module morph-l2/token-price-oracle
 
 go 1.24.0
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 replace (
 	github.com/VictoriaMetrics/fastcache => github.com/VictoriaMetrics/fastcache v1.12.2

--- a/token-price-oracle/go.sum
+++ b/token-price-oracle/go.sum
@@ -143,8 +143,8 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/remote-signer-client/go v0.0.0-20260312080033-d078d86ddbe9 h1:d2nKLUgiEJsQmpSWEiGbsC+sZXQCM4y/3EzyXkoMM60=
 github.com/morph-l2/remote-signer-client/go v0.0.0-20260312080033-d078d86ddbe9/go.mod h1:slD6GmYEwLHn4Yj/kO8/1QF3iaYlVVAXg2ZnGr8SW/8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/tx-submitter/go.mod
+++ b/tx-submitter/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.0.0-20260602085346-ee68e1bcf49a
 
-replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919
+replace github.com/morph-l2/go-ethereum => github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc
 
 require (
 	github.com/consensys/gnark-crypto v0.16.0

--- a/tx-submitter/go.sum
+++ b/tx-submitter/go.sum
@@ -161,8 +161,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/externalsign v0.3.1 h1:UYFDZFB0L85A4rDvuwLNBiGEi0kSmg9AZ2v8Q5O4dQo=
 github.com/morph-l2/externalsign v0.3.1/go.mod h1:b6NJ4GUiiG/gcSJsp3p8ExsIs4ZdphlrVALASnVoGJE=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919 h1:AGo3yhkYTkwD8m43leoau/DEsui/QUJaabkZJAZC4RI=
-github.com/morph-l2/go-ethereum v0.0.0-20260603075727-e0a2cd340919/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc h1:2Umr8WRDBKwCgGrQQ8yCdhn71bCuMJuecId2ClK80DU=
+github.com/morph-l2/go-ethereum v0.0.0-20260608072528-fe02cc1f10bc/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=


### PR DESCRIPTION
In local-verify mode, when a batch's last block is missing locally and its firstBlockNumber is below the verifier's VerificationStartHeight, wait for P2P/blocksync backfill instead of running L1 fill-gap derivation. Pre-upgrade (pbft-era) blocks are held by geth but not tracked at the node layer, so reconstructing them via L1 would diverge geth's height from the node's on restart. VerificationStartHeight returns MaxUint64 while the verifier history is empty, so every missing block is treated as pre-upgrade until it loads.

Also log a one-line sequencer-contract state snapshot at verifier startup (active sequencer + verification start height), and bump morph-l2/go-ethereum to the latest pinned revision.