### PR TITLE
Fix shell injection vulnerability in Docker release workflow inputs

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -26,6 +26,17 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
+      - name: Verify checkout ref matches expected tag
+        env:
+          INPUT_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          EXPECTED="${INPUT_TAG}"
+          ACTUAL=$(git tag --points-at HEAD | head -1)
+          if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+            echo "ERROR: HEAD does not point to expected tag $EXPECTED (got: $ACTUAL)"
+            exit 1
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -41,8 +52,10 @@ jobs:
 
       - name: Extract version and commit
         id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${INPUT_TAG}"
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid release tag: $TAG (expected e.g. v0.5.0)"
             exit 1
@@ -61,6 +74,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ github.event_name == 'push' && format('{0}:latest', env.IMAGE_NAME) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
fix inputs.tag inject to run shell
add Verify checkout ref matches expected tag
only push event can push latest image