### PR TITLE
fix(derivation): clamp deriveForce skipNumber to batch tip

### DIFF
--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -905,6 +905,32 @@ func (d *Derivation) deriveForce(rollupData *BatchInfo, skipNumber uint64) (*eth
 		return nil, fmt.Errorf("invalid firstBlockNumber 0 for batch %d", rollupData.batchIndex)
 	}
 
+	// Race short-circuit: scenario C dispatch is decided before reactors are
+	// quiesced (HeaderByNumber check at derivationBlock vs StopReactors inside
+	// withReactorsQuiesced), so blocksync can backfill past lastBlockNumber in
+	// that small window. When that happens, skipNumber (= localLatest read
+	// after Stop) ends up >= the batch tip. Without this guard the loop below
+	// would `continue` on every block, return header(skipNumber) — a block
+	// past the batch — and then verifyBatchRoots / advanceSafe upstream would
+	// run against the wrong header (false stateException + safe head pushed
+	// past the batch). Returning header(lastBlockNumber) collapses this case
+	// to the same outcome scenario A would have produced if the dispatch had
+	// caught the now-present batch tip.
+	if skipNumber >= rollupData.lastBlockNumber {
+		lastHeader, err := d.l2Client.HeaderByNumber(d.ctx, big.NewInt(int64(rollupData.lastBlockNumber)))
+		if err != nil {
+			return nil, fmt.Errorf("read batch tip at %d: %w", rollupData.lastBlockNumber, err)
+		}
+		if lastHeader == nil {
+			return nil, fmt.Errorf("batch tip at %d missing", rollupData.lastBlockNumber)
+		}
+		d.logger.Info("deriveForce: P2P caught up past batch tip during scenario-C dispatch window; no-op write",
+			"batchIndex", rollupData.batchIndex,
+			"lastBlockNumber", rollupData.lastBlockNumber,
+			"skipNumber", skipNumber)
+		return lastHeader, nil
+	}
+
 	// Anchor: parent of the first block we will WRITE must exist locally.
 	// scenario B (skipNumber==0): firstNum-1.
 	// scenario C: max(firstNum-1, skipNumber).


### PR DESCRIPTION
## Summary

Targets the CodeRabbit review comment on #966 ([r3340287543](https://github.com/morph-l2/morph/pull/966/files#r3340287543)).

In `deriveForce`, `skipNumber >= rollupData.lastBlockNumber` is reachable due to a small race between scenario-C dispatch and reactor quiesce; without a guard it returns a header past the batch tip and corrupts downstream `verifyBatchRoots` / `advanceSafe`.

## Why the race exists

scenario-C entry in `derivationBlock` is decided **before** `withReactorsQuiesced` stops the blocksync / broadcast reactors:

```
T0: HeaderByNumber(lastBlockNumber) → nil   // dispatch decision, P2P alive
T0..T1: fetchRollupDataByTxHash(...)         // L1 RPC, P2P still alive
T1: withReactorsQuiesced.preWrite read
T1+: StopReactorsBeforeReorg()              // P2P stops here
T2: body() reads localLatest                 // skipNumber = this value
```

Between T0 and T1+, blocksync can deliver blocks up to and past `lastBlockNumber` (peers already hold them; we were just lagging). `localLatest` read at T2 reflects that catchup, so `skipNumber >= lastBlockNumber` is physically reachable even though it should not be by the dispatch logic.

`l2Grew` is a coarse cross-poll growth signal — single misjudgements are tolerated by design. The clamp here is what makes that tolerance actually safe at the deriveForce layer.

## Symptom without the fix

When the race materialises:

1. The block loop's `if blockData.SafeL2Data.Number <= skipNumber { continue }` skips every block.
2. `deriveForce` returns `header(skipNumber)` — a block strictly past `rollupData.lastBlockNumber`.
3. `verifyBatchRoots(batchInfo, lastHeader)` compares the batch's expected post-state / withdrawal roots against a later block → mismatch → `SetBatchStatus(stateException)` (spurious alarm).
4. `tagAdvancer.advanceSafe(batchIndex, lastHeader)` pushes safe head past the batch tip → `(batchIndex, safe)` association is wrong.

## Fix

Add an early return in `deriveForce` when `skipNumber >= rollupData.lastBlockNumber`:

- Read `header(rollupData.lastBlockNumber)` from the local node (it must exist by definition of the race).
- Return it directly. Upstream now sees the same header that scenario A would produce if the dispatcher had observed the now-present batch tip.

The early return runs inside `withReactorsQuiesced`'s `body`, so the deferred `StartReactorsAfterReorg` still fires — reactors are restarted normally.

## Test plan

- [ ] Unit-test or manual trace verifying that a `BatchInfo` with `lastBlockNumber <= skipNumber` returns `header(lastBlockNumber)` and writes nothing.
- [ ] Manual or integration scenario where blocksync catches up between dispatch and quiesce: confirm no `stateException` is raised and `safeHead` matches `batchInfo.lastBlockNumber`.
- [ ] Existing scenario B (skipNumber==0) and scenario C with a true gap (`skipNumber < lastBlockNumber`) still write blocks as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)