### PR TITLE
fix(node): restore validator flag compatibility

### DIFF
--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -162,12 +162,7 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		c.VerifyMode = VerifyModeLayer1
 	}
 	if ctx.GlobalIsSet(flags.DerivationVerifyMode.Name) {
-		verifyMode := ctx.GlobalString(flags.DerivationVerifyMode.Name)
-		if legacyValidatorMode && verifyMode != VerifyModeLayer1 {
-			log.Warn("--validator ignored because derivation.verify-mode is explicitly set",
-				"derivation.verify-mode", verifyMode)
-		}
-		c.VerifyMode = verifyMode
+		c.VerifyMode = ctx.GlobalString(flags.DerivationVerifyMode.Name)
 	}
 	normalized, err := validateAndDefaultVerifyMode(c.VerifyMode)
 	if err != nil {

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -69,17 +69,6 @@ func validateAndDefaultVerifyMode(s string) (string, error) {
 	}
 }
 
-func resolveVerifyMode(current string, verifyModeSet bool, verifyMode string, legacyValidator bool) (string, error) {
-	switch {
-	case verifyModeSet:
-		return validateAndDefaultVerifyMode(verifyMode)
-	case legacyValidator:
-		return VerifyModeLayer1, nil
-	default:
-		return validateAndDefaultVerifyMode(current)
-	}
-}
-
 type Config struct {
 	L1                    *types.L1Config `json:"l1"`
 	L2                    *types.L2Config `json:"l2"`
@@ -167,12 +156,13 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		}
 	}
 
-	normalized, err := resolveVerifyMode(
-		c.VerifyMode,
-		ctx.GlobalIsSet(flags.DerivationVerifyMode.Name),
-		ctx.GlobalString(flags.DerivationVerifyMode.Name),
-		ctx.GlobalBool(flags.LegacyValidatorMode.Name),
-	)
+	if ctx.GlobalBool(flags.LegacyValidatorMode.Name) {
+		c.VerifyMode = VerifyModeLayer1
+	}
+	if ctx.GlobalIsSet(flags.DerivationVerifyMode.Name) {
+		c.VerifyMode = ctx.GlobalString(flags.DerivationVerifyMode.Name)
+	}
+	normalized, err := validateAndDefaultVerifyMode(c.VerifyMode)
 	if err != nil {
 		return err
 	}

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -156,11 +156,18 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		}
 	}
 
-	if ctx.GlobalBool(flags.LegacyValidatorMode.Name) {
+	legacyValidatorMode := ctx.GlobalBool(flags.LegacyValidatorMode.Name)
+	if legacyValidatorMode {
+		log.Warn("--validator is deprecated; use --derivation.verify-mode=layer1")
 		c.VerifyMode = VerifyModeLayer1
 	}
 	if ctx.GlobalIsSet(flags.DerivationVerifyMode.Name) {
-		c.VerifyMode = ctx.GlobalString(flags.DerivationVerifyMode.Name)
+		verifyMode := ctx.GlobalString(flags.DerivationVerifyMode.Name)
+		if legacyValidatorMode && verifyMode != VerifyModeLayer1 {
+			log.Warn("--validator ignored because derivation.verify-mode is explicitly set",
+				"derivation.verify-mode", verifyMode)
+		}
+		c.VerifyMode = verifyMode
 	}
 	normalized, err := validateAndDefaultVerifyMode(c.VerifyMode)
 	if err != nil {

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -69,6 +69,17 @@ func validateAndDefaultVerifyMode(s string) (string, error) {
 	}
 }
 
+func resolveVerifyMode(current string, verifyModeSet bool, verifyMode string, legacyValidator bool) (string, error) {
+	switch {
+	case verifyModeSet:
+		return validateAndDefaultVerifyMode(verifyMode)
+	case legacyValidator:
+		return VerifyModeLayer1, nil
+	default:
+		return validateAndDefaultVerifyMode(current)
+	}
+}
+
 type Config struct {
 	L1                    *types.L1Config `json:"l1"`
 	L2                    *types.L2Config `json:"l2"`
@@ -156,10 +167,12 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		}
 	}
 
-	if ctx.GlobalIsSet(flags.DerivationVerifyMode.Name) {
-		c.VerifyMode = ctx.GlobalString(flags.DerivationVerifyMode.Name)
-	}
-	normalized, err := validateAndDefaultVerifyMode(c.VerifyMode)
+	normalized, err := resolveVerifyMode(
+		c.VerifyMode,
+		ctx.GlobalIsSet(flags.DerivationVerifyMode.Name),
+		ctx.GlobalString(flags.DerivationVerifyMode.Name),
+		ctx.GlobalBool(flags.LegacyValidatorMode.Name),
+	)
 	if err != nil {
 		return err
 	}

--- a/node/derivation/config_test.go
+++ b/node/derivation/config_test.go
@@ -1,8 +1,14 @@
 package derivation
 
 import (
+	"flag"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/urfave/cli"
+
+	"morph-l2/node/flags"
 )
 
 // SPEC-005 section 4.2 + 5.1 verify-mode dispatch tests. The mode is bound at
@@ -36,22 +42,27 @@ func TestVerifyMode_AcceptsExplicitModes(t *testing.T) {
 }
 
 func TestVerifyMode_LegacyValidatorAlias(t *testing.T) {
-	got, err := resolveVerifyMode(DefaultVerifyMode, false, "", true)
-	if err != nil {
+	cfg := DefaultConfig()
+	if err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.LegacyValidatorMode.Name: "true",
+	})); err != nil {
 		t.Fatalf("legacy validator alias rejected: %v", err)
 	}
-	if got != VerifyModeLayer1 {
-		t.Fatalf("legacy validator alias resolved to %q, want %q", got, VerifyModeLayer1)
+	if cfg.VerifyMode != VerifyModeLayer1 {
+		t.Fatalf("legacy validator alias resolved to %q, want %q", cfg.VerifyMode, VerifyModeLayer1)
 	}
 }
 
 func TestVerifyMode_ExplicitModeOverridesLegacyValidatorAlias(t *testing.T) {
-	got, err := resolveVerifyMode(DefaultVerifyMode, true, VerifyModeLocal, true)
-	if err != nil {
+	cfg := DefaultConfig()
+	if err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.LegacyValidatorMode.Name:  "true",
+		flags.DerivationVerifyMode.Name: VerifyModeLocal,
+	})); err != nil {
 		t.Fatalf("explicit verify-mode rejected: %v", err)
 	}
-	if got != VerifyModeLocal {
-		t.Fatalf("explicit verify-mode resolved to %q, want %q", got, VerifyModeLocal)
+	if cfg.VerifyMode != VerifyModeLocal {
+		t.Fatalf("explicit verify-mode resolved to %q, want %q", cfg.VerifyMode, VerifyModeLocal)
 	}
 }
 
@@ -85,4 +96,35 @@ func validateAndDefaultVerifyModeErr(t *testing.T, s string) error {
 		t.Fatalf("expected error on verify-mode %q, got nil", s)
 	}
 	return err
+}
+
+func newVerifyModeTestContext(t *testing.T, values map[string]string) *cli.Context {
+	t.Helper()
+
+	flagSet := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	for _, f := range []cli.Flag{
+		flags.LegacyValidatorMode,
+		flags.DerivationVerifyMode,
+		flags.L1BeaconAddr,
+		flags.L2EngineJWTSecret,
+	} {
+		f.Apply(flagSet)
+	}
+
+	defaults := map[string]string{
+		flags.L1BeaconAddr.Name:      "http://beacon.example",
+		flags.L2EngineJWTSecret.Name: filepath.Join(t.TempDir(), "jwt.hex"),
+	}
+	for name, value := range defaults {
+		if err := flagSet.Set(name, value); err != nil {
+			t.Fatalf("set default flag %s: %v", name, err)
+		}
+	}
+	for name, value := range values {
+		if err := flagSet.Set(name, value); err != nil {
+			t.Fatalf("set flag %s: %v", name, err)
+		}
+	}
+
+	return cli.NewContext(cli.NewApp(), flagSet, nil)
 }

--- a/node/derivation/config_test.go
+++ b/node/derivation/config_test.go
@@ -35,6 +35,26 @@ func TestVerifyMode_AcceptsExplicitModes(t *testing.T) {
 	}
 }
 
+func TestVerifyMode_LegacyValidatorAlias(t *testing.T) {
+	got, err := resolveVerifyMode(DefaultVerifyMode, false, "", true)
+	if err != nil {
+		t.Fatalf("legacy validator alias rejected: %v", err)
+	}
+	if got != VerifyModeLayer1 {
+		t.Fatalf("legacy validator alias resolved to %q, want %q", got, VerifyModeLayer1)
+	}
+}
+
+func TestVerifyMode_ExplicitModeOverridesLegacyValidatorAlias(t *testing.T) {
+	got, err := resolveVerifyMode(DefaultVerifyMode, true, VerifyModeLocal, true)
+	if err != nil {
+		t.Fatalf("explicit verify-mode rejected: %v", err)
+	}
+	if got != VerifyModeLocal {
+		t.Fatalf("explicit verify-mode resolved to %q, want %q", got, VerifyModeLocal)
+	}
+}
+
 func TestVerifyMode_RejectsUnknown(t *testing.T) {
 	// "hybrid" was the old default; ensure post-removal it's rejected so
 	// stale operator configs fail loud rather than silently falling back to

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -156,6 +156,12 @@ var (
 		EnvVar: prefixEnvVar("MOCK_SEQUENCER"),
 	}
 
+	LegacyValidatorMode = cli.BoolFlag{
+		Name:   "validator",
+		Usage:  "Deprecated compatibility alias for --derivation.verify-mode=layer1",
+		EnvVar: prefixEnvVar("VALIDATOR"),
+	}
+
 	// derivation
 	RollupContractAddress = cli.StringFlag{
 		Name:   "derivation.rollupAddress",
@@ -368,6 +374,7 @@ var Flags = []cli.Flag{
 	DevSequencer,
 	TendermintConfigPath,
 	MockEnabled,
+	LegacyValidatorMode,
 
 	// derivation
 	RollupContractAddress,


### PR DESCRIPTION
## Summary
- Restore `--validator` as a deprecated compatibility alias.
- Resolve legacy validator mode to `--derivation.verify-mode=layer1` so existing validator configs keep working after binary upgrade.
- Add verify-mode tests for the legacy alias and explicit override behavior.

## Test plan
- `go test ./node/derivation`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--validator` CLI flag as a deprecated compatibility alias for verify-mode configuration

* **Tests**
  * Added tests for legacy validator mode resolution and explicit mode override scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->