### PR TITLE
feat(gas-oracle): make L1 base/blob fee caps configurable via env

### DIFF
--- a/gas-oracle/app/src/gas_price_oracle.rs
+++ b/gas-oracle/app/src/gas_price_oracle.rs
@@ -36,6 +36,8 @@ struct Config {
     l1_beacon_rpc: String,
     l1_base_fee_buffer: u64,
     l1_blob_base_fee_buffer: u64,
+    max_l1_base_fee: u64,
+    max_l1_blob_base_fee: u64,
     commit_scalar_buffer: u64,
     blob_scalar_buffer: u64,
     finalize_batch_gas_used: u64,
@@ -65,6 +67,8 @@ impl Config {
             l1_beacon_rpc: read_parse_env("GAS_ORACLE_L1_BEACON_RPC"),
             l1_base_fee_buffer: read_env_var("GAS_ORACLE_L1_BASE_FEE_BUFFER", 0u64),
             l1_blob_base_fee_buffer: read_env_var("GAS_ORACLE_L1_BLOB_BASE_FEE_BUFFER", 0u64),
+            max_l1_base_fee: read_env_var("GAS_ORACLE_MAX_L1_BASE_FEE", 1000 * 10u64.pow(9)),
+            max_l1_blob_base_fee: read_env_var("GAS_ORACLE_MAX_L1_BLOB_BASE_FEE", 100 * 10u64.pow(9)),
             commit_scalar_buffer: read_env_var("GAS_ORACLE_COMMIT_SCALAR_BUFFER", 0u64),
             blob_scalar_buffer: read_env_var("GAS_ORACLE_BLOB_SCALAR_BUFFER", 0u64),
             finalize_batch_gas_used: read_env_var("GAS_ORACLE_FINALIZE_BATCH_GAS_USED", 113100u64),
@@ -210,6 +214,8 @@ async fn prepare_updater(
         config.gas_threshold,
         config.l1_base_fee_buffer,
         config.l1_blob_base_fee_buffer,
+        config.max_l1_base_fee,
+        config.max_l1_blob_base_fee,
     );
 
     let scalar_updater = ScalarUpdater::new(

--- a/gas-oracle/app/src/l1_base_fee.rs
+++ b/gas-oracle/app/src/l1_base_fee.rs
@@ -8,9 +8,6 @@ use ethers::prelude::*;
 use eyre::anyhow;
 use remote_signer_client::SignerClient;
 
-const MAX_BASE_FEE: u128 = 1000 * 10i32.pow(9) as u128; // 1000Gwei
-const MAX_BLOB_BASE_FEE: u128 = 100 * 10i32.pow(9) as u128; // 100Gwei
-
 pub struct BaseFeeUpdater {
     l1_provider: Provider<Http>,
     l2_provider: Provider<Http>,
@@ -19,6 +16,10 @@ pub struct BaseFeeUpdater {
     gas_threshold: u64,
     l1_base_fee_buffer: u64,
     l1_blob_base_fee_buffer: u64,
+    // Upper caps applied to the fetched L1 fees before pushing them on-chain.
+    // Configurable via env; defaults preserve the historical 1000/100 Gwei limits.
+    max_l1_base_fee: u64,
+    max_l1_blob_base_fee: u64,
 }
 
 impl BaseFeeUpdater {
@@ -30,6 +31,8 @@ impl BaseFeeUpdater {
         gas_threshold: u64,
         l1_base_fee_buffer: u64,
         l1_blob_base_fee_buffer: u64,
+        max_l1_base_fee: u64,
+        max_l1_blob_base_fee: u64,
     ) -> Self {
         BaseFeeUpdater {
             l1_provider,
@@ -39,6 +42,8 @@ impl BaseFeeUpdater {
             gas_threshold,
             l1_base_fee_buffer,
             l1_blob_base_fee_buffer,
+            max_l1_base_fee,
+            max_l1_blob_base_fee,
         }
     }
 
@@ -127,8 +132,8 @@ impl BaseFeeUpdater {
         base_fee_on_l2: U256,
         blob_fee_on_l2: U256,
     ) -> Result<(), OracleError> {
-        l1_base_fee = l1_base_fee.min(MAX_BASE_FEE.into());
-        l1_blob_base_fee = l1_blob_base_fee.min(MAX_BLOB_BASE_FEE.into());
+        l1_base_fee = l1_base_fee.min(U256::from(self.max_l1_base_fee));
+        l1_blob_base_fee = l1_blob_base_fee.min(U256::from(self.max_l1_blob_base_fee));
 
         // update_base_fee
         let actual_change = l1_blob_base_fee.abs_diff(blob_fee_on_l2);


### PR DESCRIPTION
## What
The upper caps applied to the fetched L1 base fee and blob base fee in `gas-oracle` were hardcoded:

```rust
const MAX_BASE_FEE: u128 = 1000 * 10i32.pow(9) as u128;      // 1000 Gwei
const MAX_BLOB_BASE_FEE: u128 = 100 * 10i32.pow(9) as u128;  // 100 Gwei
```

During sustained L1 fee spikes these caps silently clamp the value pushed on-chain, and there is no way to tune them without a rebuild/redeploy.

## Change
- Move both caps into `Config`, read from env `GAS_ORACLE_MAX_L1_BASE_FEE` / `GAS_ORACLE_MAX_L1_BLOB_BASE_FEE`.
- Defaults equal the previous constants (1000 Gwei / 100 Gwei), so **behavior is unchanged unless explicitly overridden**.
- Thread the two values through `BaseFeeUpdater::new`, mirroring the existing `gas_threshold` / `*_buffer` config pattern.

Two files, no public API change beyond the internal constructor (its only caller is updated).

## Context
Surfaced by morph-l2/morph-ideas idea #005 (hardcoded fee-cap tech debt): https://github.com/morph-l2/morph-ideas/blob/main/idea-005.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum limits for L1 base fees and L1 blob fees.
  * Operators can set these limits through environment variables, with safe defaults when values are not provided.

* **Bug Fixes**
  * L1 fee calculations are now capped according to the configured limits, helping prevent unexpectedly high fee values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->