### PR TITLE
fix(node/sync): fail fast if L2CrossDomainMessenger ABI fails to parse

### DIFF
--- a/node/sync/deposit_log.go
+++ b/node/sync/deposit_log.go
@@ -19,6 +19,15 @@ var (
 	L2CrossDomainMessengerABI, _ = bindings.L2CrossDomainMessengerMetaData.GetAbi()
 )
 
+// init fails fast at startup if the generated L2CrossDomainMessenger ABI cannot
+// be parsed, instead of letting the dropped error above surface later as an
+// obscure nil-dereference the first time L2CrossDomainMessengerABI is used.
+func init() {
+	if _, err := bindings.L2CrossDomainMessengerMetaData.GetAbi(); err != nil {
+		panic(fmt.Sprintf("parse L2CrossDomainMessenger ABI: %v", err))
+	}
+}
+
 func L1MessageTxFromEvent(event *bindings.L1MessageQueueWithGasPriceOracleQueueTransaction) eth.L1MessageTx {
 	return eth.L1MessageTx{
 		QueueIndex: event.QueueIndex,


### PR DESCRIPTION
## What
`node/sync/deposit_log.go` parses the L2CrossDomainMessenger ABI at package level but drops the error with a blank identifier:

```go
L2CrossDomainMessengerABI, _ = bindings.L2CrossDomainMessengerMetaData.GetAbi()
```

If the generated ABI ever failed to parse, `L2CrossDomainMessengerABI` would be `nil` and only surface much later as an obscure nil-dereference at first use.

## Change
Add an `init()` that re-checks and `panic`s at startup, so a broken ABI is caught at deploy time rather than deep in request handling. The normal (success) path is unchanged.

Minimal, one file, `fmt` already imported.

## Context
Surfaced by morph-l2/morph-ideas idea #003 (silent error swallowing): https://github.com/morph-l2/morph-ideas/blob/main/idea-003.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)