### PR TITLE
fix(node): restore layer1-verify validator startup defaults

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/morph-l2/go-ethereum/crypto"
 	"github.com/morph-l2/go-ethereum/ethclient"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	tmcrypto "github.com/tendermint/tendermint/crypto"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmnode "github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/privval"
@@ -131,8 +132,30 @@ func L2NodeMain(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	tmVal := privval.LoadOrGenFilePV(tmCfg.PrivValidatorKeyFile(), tmCfg.PrivValidatorStateFile())
-	pubKey, _ := tmVal.GetPubKey()
+
+	// Load derivation config here (not just before the switch below): its
+	// VerifyMode decides whether this node runs the Tendermint consensus node,
+	// which in turn decides whether we need a priv-validator file.
+	derivationCfg := derivation.DefaultConfig()
+	if err := derivationCfg.SetCliContext(ctx); err != nil {
+		return fmt.Errorf("derivation set cli context error: %v", err)
+	}
+
+	// Only nodes that start the Tendermint consensus node need a priv-validator
+	// key/state file. Layer1-verify validators never start Tendermint (see the
+	// switch below); LoadOrGenFilePV would generate and Save a FilePV, forcing a
+	// <home>/data/ directory that from-scratch validators never had and panicking
+	// when it is absent. Skip it and hand the executor a nil pubkey -- NewExecutor
+	// and the sequencer-set check both tolerate nil (a layer1 validator is never
+	// in the sequencer set, so its "am I a sequencer" check is correctly false).
+	var (
+		tmVal  *privval.FilePV
+		pubKey tmcrypto.PubKey
+	)
+	if derivationCfg.VerifyMode != derivation.VerifyModeLayer1 {
+		tmVal = privval.LoadOrGenFilePV(tmCfg.PrivValidatorKeyFile(), tmCfg.PrivValidatorStateFile())
+		pubKey, _ = tmVal.GetPubKey()
+	}
 
 	// Reuse the shared syncer instance -- DevSequencer mode is the only path
 	// that pulls a syncer out of NewExecutor, so we hand back the same one
@@ -156,12 +179,6 @@ func L2NodeMain(ctx *cli.Context) error {
 	haService, err = initHAService(ctx, home, nodeConfig.Logger)
 	if err != nil {
 		return err
-	}
-
-	// ========== Derivation config (loaded early to drive the layer1 branch below) ==========
-	derivationCfg := derivation.DefaultConfig()
-	if err := derivationCfg.SetCliContext(ctx); err != nil {
-		return fmt.Errorf("derivation set cli context error: %v", err)
 	}
 
 	switch {

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -170,6 +170,14 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 	}
 	c.VerifyMode = normalized
 
+	// Layer1-verify validators historically derived only from finalized L1 data
+	// (the pre-centralized-sequencer default). Preserve that: unless the operator
+	// explicitly set --derivation.confirmations, a layer1 node reads finalized
+	// rather than the fixed-depth latest-N default that consensus fullnodes use.
+	if c.VerifyMode == VerifyModeLayer1 && !ctx.GlobalIsSet(flags.DerivationConfirmations.Name) {
+		c.L1.Confirmations = rpc.FinalizedBlockNumber
+	}
+
 	if ctx.GlobalIsSet(flags.DerivationReorgCheckDepth.Name) {
 		c.ReorgCheckDepth = ctx.GlobalUint64(flags.DerivationReorgCheckDepth.Name)
 	}


### PR DESCRIPTION
## Problem

A from-scratch **layer1-verify validator** panics on startup:

```
panic: open /opt/data/data/write-file-atomic-...: no such file or directory
  privval.(*FilePVLastSignState).Save
  privval.LoadOrGenFilePV
  main.L2NodeMain  (node/cmd/node/main.go:134)
```

Two behaviors regressed when PR #966 (centralized sequencer) merged the old `if isValidator { ... } else { ... }` split into one unified startup path:

1. **`LoadOrGenFilePV` became unconditional.** Pre-#966, layer1 validators ran the derivation path and never touched Tendermint priv-validator. Now every node calls it — but a layer1 validator never starts Tendermint and has no `<home>/data/` dir, so `LoadOrGenFilePV` → `Save()` → `write-file-atomic` fails to create its temp file and panics.
2. **`derivation.confirmations` default changed** from `finalized` (pre-#966) to a fixed latest-10 depth. That's the intended default for consensus fullnodes (paired with the reorg detector), but it silently changed validator behavior.

## Fix

- **main.go**: load the derivation config before the priv-validator step; only `LoadOrGenFilePV` when the node will actually start Tendermint (i.e. `VerifyMode != layer1`). Layer1 validators hand the executor a `nil` pubkey — both `NewExecutor` (`executor.go:92-94`) and the sequencer-set check tolerate nil, and a layer1 validator is correctly never matched as a sequencer.
- **config.go**: for `VerifyMode == layer1`, default `Confirmations` back to `rpc.FinalizedBlockNumber` — **unless** the operator explicitly set `--derivation.confirmations`. Consensus fullnodes keep the latest-N default and the reorg detector.

## Scope / compatibility

- Only affects layer1-verify (validator) nodes. Sequencer and local-verify fullnodes are unchanged.
- Explicit `--derivation.confirmations` still wins.
- No new `<home>/data/` requirement for validators — restores pre-#966 behavior.

## Test

- `go build ./cmd/... ./derivation/...` ✅
- `go vet ./derivation/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Layer 1 verification support that skips unnecessary validator initialization.
  * Layer 1 verification now defaults to finalized block confirmations when no custom confirmation setting is provided.

* **Bug Fixes**
  * Preserved the ability to override the default confirmation behavior with an explicit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->