### PR TITLE
fix(node): restore layer1 validator metrics overrides

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -51,6 +53,8 @@ func main() {
 	}
 }
 
+// L2NodeMain initializes and runs the Morph node for the selected verification
+// and sequencer mode.
 func L2NodeMain(ctx *cli.Context) error {
 	var (
 		err       error
@@ -190,9 +194,26 @@ func L2NodeMain(ctx *cli.Context) error {
 		go ms.Start()
 	case derivationCfg.VerifyMode == derivation.VerifyModeLayer1:
 		nodeConfig.Logger.Info("layer1 verify mode: tendermint not started")
-		// Other modes inherit /metrics from tendermint; layer1 has to bring
-		// its own listener up on the same address.
-		startMetricsServer(tmCfg.Instrumentation.PrometheusListenAddr, nodeConfig.Logger)
+		// Other modes inherit /metrics from tendermint; layer1 has to bring its
+		// own listener up. Default to the Tendermint [instrumentation] address
+		// from config.toml, but let --metrics-port / METRICS_PORT replace only
+		// its port while preserving the configured hostname.
+		if ctx.GlobalIsSet(flags.MetricsServerEnable.Name) {
+			tmCfg.Instrumentation.Prometheus = ctx.GlobalBool(flags.MetricsServerEnable.Name)
+		}
+		if tmCfg.Instrumentation.Prometheus {
+			if ctx.GlobalIsSet(flags.MetricsPort.Name) {
+				host, _, err := net.SplitHostPort(tmCfg.Instrumentation.PrometheusListenAddr)
+				if err != nil && tmCfg.Instrumentation.PrometheusListenAddr != "" {
+					return fmt.Errorf("invalid instrumentation.prometheus_listen_addr: %w", err)
+				}
+				tmCfg.Instrumentation.PrometheusListenAddr = net.JoinHostPort(
+					host,
+					strconv.FormatUint(derivationCfg.MetricsPort, 10),
+				)
+			}
+			startMetricsServer(tmCfg.Instrumentation.PrometheusListenAddr, nodeConfig.Logger)
+		}
 	default:
 		// Convert typed nil (*HAService)(nil) to untyped nil interface to avoid
 		// Go's nil interface gotcha: a typed nil satisfies (ha != nil) checks.
@@ -426,6 +447,8 @@ func initL1SequencerComponents(
 	return tracker, verifier, signer, nil
 }
 
+// startMetricsServer starts the metrics HTTP server asynchronously when addr
+// is non-empty.
 func startMetricsServer(addr string, logger tmlog.Logger) {
 	if addr == "" {
 		logger.Info("metrics server disabled (instrumentation.prometheus_listen_addr is empty)")

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -81,8 +81,10 @@ type Config struct {
 	FetchBlockRange       uint64          `json:"fetch_block_range"`
 	VerifyMode            string          `json:"verify_mode"`
 	ReorgCheckDepth       uint64          `json:"reorg_check_depth"`
+	MetricsPort           uint64          `json:"metrics_port"`
 }
 
+// DefaultConfig returns the default derivation configuration.
 func DefaultConfig() *Config {
 	return &Config{
 		L1: &types.L1Config{
@@ -103,6 +105,8 @@ func DefaultConfig() *Config {
 	}
 }
 
+// SetCliContext applies command-line and environment overrides to the
+// derivation configuration.
 func (c *Config) SetCliContext(ctx *cli.Context) error {
 	c.L1.Addr = ctx.GlobalString(flags.L1NodeAddr.Name)
 	// The current setting priority is greater than Env L1Confirmations
@@ -169,6 +173,10 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 		return err
 	}
 	c.VerifyMode = normalized
+
+	if c.VerifyMode == VerifyModeLayer1 {
+		c.MetricsPort = ctx.GlobalUint64(flags.MetricsPort.Name)
+	}
 
 	// Layer1-verify validators historically derived only from finalized L1 data
 	// (the pre-centralized-sequencer default). Preserve that: unless the operator

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -344,6 +344,21 @@ var (
 		Usage:  "Compress determines if the rotated log files should be compressed using gzip. The default is not to perform compression. It is used only when log.filename is provided.",
 		EnvVar: prefixEnvVar("LOG_COMPRESS"),
 	}
+
+	// metrics
+	MetricsServerEnable = cli.BoolFlag{
+		Name:   "metrics-server-enable",
+		Usage:  "Whether the layer1 validator serves Prometheus metrics. Overrides [instrumentation] prometheus from config.toml when explicitly set.",
+		EnvVar: prefixEnvVar("METRICS_SERVER_ENABLE"),
+	}
+	// MetricsPort optionally overrides the layer1 validator metrics port. When
+	// unset, the complete Tendermint instrumentation address is preserved.
+	MetricsPort = cli.Uint64Flag{
+		Name:   "metrics-port",
+		Usage:  "Port the validator metrics server binds to. Overrides [instrumentation] prometheus_listen_addr from config.toml when set (layer1 verify mode only).",
+		Value:  26660,
+		EnvVar: prefixEnvVar("METRICS_PORT"),
+	}
 )
 
 var Flags = []cli.Flag{
@@ -412,4 +427,8 @@ var Flags = []cli.Flag{
 	LogFileMaxSize,
 	LogFileMaxAge,
 	LogCompress,
+
+	// metrics
+	MetricsServerEnable,
+	MetricsPort,
 }


### PR DESCRIPTION
## Problem

PR #966 removed the standalone layer1 validator metrics CLI/environment overrides. Operators can configure metrics through Tendermint `[instrumentation]`, but can no longer override the enable switch or listener port from deployment environment variables without editing `config.toml`.

## Fix

Restore two overrides for layer1 verification mode only:

- `--metrics-server-enable` / `MORPH_NODE_METRICS_SERVER_ENABLE` overrides `[instrumentation] prometheus` for the standalone layer1 validator listener.
- `--metrics-port` / `MORPH_NODE_METRICS_PORT` replaces only that listener port while preserving the hostname from `prometheus_listen_addr`.

When neither option is set, behavior comes entirely from `config.toml`. Other modes continue using Tendermint metrics and are unaffected by these compatibility flags.

## Validation

- `go test ./derivation ./cmd/node ./flags`
- `make -C node lint`