### PR TITLE
fix(hakeeper): reject empty RPC auth token to prevent write-API bypass

### DIFF
--- a/node/hakeeper/rpc/auth.go
+++ b/node/hakeeper/rpc/auth.go
@@ -24,11 +24,13 @@ type rpcEnvelope struct {
 }
 
 // authMiddleware returns an HTTP handler that enforces token auth on write methods.
-// If token is empty, the middleware is disabled and all requests pass through.
+// It is fail-closed: empty token is treated as unauthorized.
 func authMiddleware(token string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if token == "" {
-			next.ServeHTTP(w, r)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"unauthorized"}}`))
 			return
 		}
 

--- a/node/hakeeper/rpc/auth_test.go
+++ b/node/hakeeper/rpc/auth_test.go
@@ -65,7 +65,15 @@ func TestAuthMiddleware_WriteMethod_WrongToken_Returns401(t *testing.T) {
 }
 
 func TestAuthMiddleware_EmptyToken_AllMethodsPass(t *testing.T) {
-	t.Skip("empty token is still allowed at middleware level, but rejected by Server.New() in production path")
+	h := authMiddleware("", okHandler)
+	body := `{"jsonrpc":"2.0","method":"ha_removeServer","params":["node-2",1],"id":1}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with empty token, got %d", rr.Code)
+	}
 }
 
 func TestAuthMiddleware_BatchRequest_WithWriteMethod_NoToken_Returns401(t *testing.T) {

--- a/node/hakeeper/rpc/auth_test.go
+++ b/node/hakeeper/rpc/auth_test.go
@@ -65,15 +65,7 @@ func TestAuthMiddleware_WriteMethod_WrongToken_Returns401(t *testing.T) {
 }
 
 func TestAuthMiddleware_EmptyToken_AllMethodsPass(t *testing.T) {
-	h := authMiddleware("", okHandler)
-	body := `{"jsonrpc":"2.0","method":"ha_removeServer","params":["node-2",1],"id":1}`
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200 (auth disabled), got %d", rr.Code)
-	}
+	t.Skip("empty token is still allowed at middleware level, but rejected by Server.New() in production path")
 }
 
 func TestAuthMiddleware_BatchRequest_WithWriteMethod_NoToken_Returns401(t *testing.T) {

--- a/node/hakeeper/rpc/server.go
+++ b/node/hakeeper/rpc/server.go
@@ -23,17 +23,17 @@ type Server struct {
 }
 
 // New creates a new Server. cons must implement ConsensusAdapter (defined in this package).
-// token is the auth token for write APIs; pass empty string to disable auth.
+// token is the auth token for write APIs; empty is rejected so write APIs cannot be unintentionally exposed.
 func New(log log.Logger, listenAddr string, listenPort int, cons ConsensusAdapter, token string) (*Server, error) {
+	if token == "" {
+		return nil, errors.New("hakeeper RPC auth token must not be empty; set --ha.rpc-token or MORPH_NODE_HA_RPC_TOKEN")
+	}
+
 	rpcSrv := ethrpc.NewServer()
 
 	backend := NewAPIBackend(log, cons)
 	if err := rpcSrv.RegisterName(RPCNamespace, backend); err != nil {
 		return nil, errors.Wrap(err, "failed to register hakeeper API")
-	}
-
-	if token == "" {
-		log.Info("hakeeper RPC server has no auth token configured, write APIs are unprotected")
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary
- Fail-closed change in `node/hakeeper/rpc/server.go`: empty HA RPC auth token is now rejected instead of disabling write-API protection.
- Updated `node/hakeeper/rpc/auth_test.go` to reflect the new behavior.

## Motivation
Empty/missing auth token previously disabled ALL authentication on write RPCs, exposing methods like `ha_addServerAsVoter`, `ha_removeServer`, `ha_transferLeader`, etc. This allows an unauthenticated attacker to takeover the HA cluster by adding a malicious node and transferring leadership.

## Security Impact
**High**: Cluster takeover via HA RPC auth bypass.

## Fix
Reject empty token in `Server.New()` with a clear error instructing operators to set `--ha.rpc-token` or `MORPH_NODE_HA_RPC_TOKEN`.

## Checklist
- [x] Change is minimal and focused
- [x] No breaking changes to existing authenticated callers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Write APIs now require a non-empty authentication token when the RPC server starts.
  - Prevents the server from running with unprotected write operations.
  - Updated authentication coverage to reflect the enforced startup validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->