### PR TITLE
fix(common): bound RLP transaction allocations

### DIFF
--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -235,6 +235,13 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	}
 	size := binary.BigEndian.Uint32(append(make([]byte, 4-len(sizeByte)), sizeByte...))
 
+	// Reject malformed lengths before allocating attacker-controlled memory.
+	// Batch decoding currently passes a *bytes.Reader, whose remaining length
+	// provides a strict upper bound for the encoded transaction payload.
+	if lr, ok := reader.(interface{ Len() int }); ok && uint64(size) > uint64(lr.Len()) {
+		return nil, fmt.Errorf("declared tx size %d exceeds remaining %d bytes", size, lr.Len())
+	}
+
 	txRaw := make([]byte, size)
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err

--- a/common/batch/blob_test.go
+++ b/common/batch/blob_test.go
@@ -1,0 +1,25 @@
+package batch
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractInnerTxFullBytesRejectsOversizedDeclaration(t *testing.T) {
+	reader := bytes.NewReader([]byte{0xff, 0xff, 0xff, 0xff})
+
+	_, err := extractInnerTxFullBytes(0xfb, reader)
+
+	require.EqualError(t, err, "declared tx size 4294967295 exceeds remaining 0 bytes")
+}
+
+func TestExtractInnerTxFullBytesAcceptsAvailablePayload(t *testing.T) {
+	reader := bytes.NewReader([]byte{3, 1, 2, 3})
+
+	got, err := extractInnerTxFullBytes(0xf8, reader)
+
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xf8, 3, 1, 2, 3}, got)
+}


### PR DESCRIPTION
## Summary
- reject RLP transaction lengths larger than the remaining decoded batch payload before allocating
- preserve all valid batch behavior while preventing a malformed length prefix from requesting multi-gigabyte memory
- cover both oversized declarations and valid payload decoding

## Security impact
A malformed committed batch can encode a four-byte RLP length such as `0xffffffff` with almost no payload. Without this check, derivation attempts the declared allocation before the subsequent read fails. The check uses the exact remaining `bytes.Reader` length rather than an arbitrary protocol cap.

## Test plan
- [x] `go test ./batch -run '^TestExtractInnerTxFullBytes' -count=1 -timeout=30s`


Made with [Cursor](https://cursor.com)