### PR TITLE
fix(node): verify blob content in beacon fallback before accepting a response

### DIFF
--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -49,12 +49,12 @@ func sidecarJSON(index int, blobHex, commitmentHex string) string {
 type beaconBehavior int
 
 const (
-	beaconServesBlob             beaconBehavior = iota // 200 with one valid sidecar
-	beaconServesEmpty                                  // 200 with an empty list (pruned / not indexed)
-	beaconServerError                                  // 500
-	beaconServesCorruptBlob                            // 200, right count and commitment, blob bytes do not match
-	beaconServesWrongCommitment                        // 200, right count, commitment of some other blob
-	beaconServesNullSidecar                            // 200, JSON null entry in the sidecar list
+	beaconServesBlob            beaconBehavior = iota // 200 with one valid sidecar
+	beaconServesEmpty                                 // 200 with an empty list (pruned / not indexed)
+	beaconServerError                                 // 500
+	beaconServesCorruptBlob                           // 200, right count and commitment, blob bytes do not match
+	beaconServesWrongCommitment                       // 200, right count, commitment of some other blob
+	beaconServesNullSidecar                           // 200, JSON null entry in the sidecar list
 )
 
 // newStubBeacon serves the genesis + spec endpoints (needed for slot math) and

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -212,8 +212,7 @@ func TestFallbackBeacon_FallsBackOnNullSidecar(t *testing.T) {
 // The #745 self-heal: when the caller cannot build index hints (the L1 block
 // body was unavailable), it passes nil hints. The client must still fetch all
 // sidecars at the slot and authenticate them by hash — a nil hint is NOT a
-// failure. Guards against turning a BlockByNumber failure back into a hard
-// error; see the DO NOT comment in fetchRollupDataByTxHash.
+// failure and must not become a hard error.
 func TestFallbackBeacon_VerifiesWithoutIndexHints(t *testing.T) {
 	primary, primaryHits := newStubBeacon(t, beaconServesBlob)
 

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/morph-l2/go-ethereum/common/hexutil"
+	"github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	"github.com/stretchr/testify/require"
 )
@@ -101,9 +102,9 @@ func (h canceledHTTP) Get(ctx context.Context, _ string, _ http.Header) (*http.R
 	return nil, ctx.Err()
 }
 
-func fetch(t *testing.T, c *FallbackBeaconClient) ([]*BlobSidecar, error) {
+func fetch(t *testing.T, c *FallbackBeaconClient) (types.BlobTxSidecar, error) {
 	t.Helper()
-	return c.GetBlobSidecarsEnhanced(context.Background(), L1BlockRef{Time: 12}, oneHash())
+	return c.GetVerifiedBlobs(context.Background(), L1BlockRef{Time: 12}, oneHash())
 }
 
 // The primary serves the blob and the fallback is never queried.
@@ -114,7 +115,7 @@ func TestFallbackBeacon_PrimaryServesBlob(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.EqualValues(t, 1, atomic.LoadInt32(primaryHits))
 	require.EqualValues(t, 0, atomic.LoadInt32(fallbackHits), "fallback must not be queried while primary serves the blob")
 }
@@ -128,7 +129,7 @@ func TestFallbackBeacon_FallsBackOnEmptyResult(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }
@@ -141,7 +142,7 @@ func TestFallbackBeacon_FallsBackOnServerError(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }
 
@@ -152,7 +153,7 @@ func TestFallbackBeacon_FallsBackOnTransportError(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{"http://127.0.0.1:0", fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }
 
@@ -165,7 +166,7 @@ func TestFallbackBeacon_FallsBackOnCorruptBlobContent(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "corrupt blob content must trigger fallback")
 }
@@ -179,7 +180,7 @@ func TestFallbackBeacon_FallsBackOnMissingRequestedHash(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecars, err := fetch(t, c)
 	require.NoError(t, err)
-	require.Len(t, sidecars, 1)
+	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "missing requested hash must trigger fallback")
 }
@@ -196,10 +197,10 @@ func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	sidecars, err := c.GetBlobSidecarsEnhanced(ctx, L1BlockRef{Time: 12}, oneHash())
+	sidecars, err := c.GetVerifiedBlobs(ctx, L1BlockRef{Time: 12}, oneHash())
 
 	require.ErrorIs(t, err, context.Canceled)
-	require.Nil(t, sidecars)
+	require.Empty(t, sidecars.Blobs)
 	require.Positive(t, atomic.LoadInt32(&primaryCalls))
 	require.Zero(t, atomic.LoadInt32(&fallbackCalls))
 }
@@ -214,7 +215,7 @@ func TestFallbackBeacon_AllFailReturnsError(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, m)
 	sidecars, err := fetch(t, c)
 	require.Error(t, err)
-	require.Nil(t, sidecars)
+	require.Empty(t, sidecars.Blobs)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -277,7 +277,7 @@ func TestFallbackBeacon_AllEmptyReturnsError(t *testing.T) {
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
 	sidecar, err := fetch(t, c)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found in beacon response")
+	require.Contains(t, err.Error(), "no sidecars")
 	require.Empty(t, sidecar.Blobs)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits))

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -14,11 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetBlobSidecarsEnhanced authenticates blob content against the requested
-// versioned hashes, so the accept-path stubs must serve a real
-// (blob, commitment) pair. The all-zero blob is the cheapest valid one: its
-// KZG commitment is computed once here and its versioned hash is what tests
-// request.
+// The fallback verifies blob content, so accept-path stubs must serve a real
+// (blob, commitment) pair; the all-zero blob is the cheapest valid one.
 var (
 	hex32 = "0x" + strings.Repeat("00", 32)
 	hex48 = "0x" + strings.Repeat("00", 48)
@@ -27,10 +24,8 @@ var (
 	zeroBlobCommitment = mustZeroBlobCommitment()
 	zeroBlobHash       = KZGToVersionedHash(zeroBlobCommitment)
 
-	// Valid field elements (first byte 0x01 < BLS modulus high byte) but not
-	// the zero blob, served under the zero blob's commitment: the count and
-	// the commitment lookup both pass, only the KZG round-trip in verifyBlob
-	// can catch it.
+	// Valid blob bytes served under the zero blob's commitment: count and
+	// commitment lookup pass, only verifyBlob catches it.
 	corruptBlobHex = "0x01" + strings.Repeat("00", BlobSize-1)
 )
 
@@ -161,10 +156,8 @@ func TestFallbackBeacon_FallsBackOnTransportError(t *testing.T) {
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }
 
-// The primary replies 200 with the right sidecar count and the right
-// commitment, but the blob bytes do not commit to the requested hash
-// (corrupted storage, wrong fork, etc.). Content verification must reject it
-// and fall back instead of handing bad bytes downstream.
+// 200 with the right count and commitment but corrupted blob bytes must
+// trigger fallback instead of handing bad bytes downstream.
 func TestFallbackBeacon_FallsBackOnCorruptBlobContent(t *testing.T) {
 	primary, primaryHits := newStubBeacon(t, beaconServesCorruptBlob)
 	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
@@ -177,9 +170,8 @@ func TestFallbackBeacon_FallsBackOnCorruptBlobContent(t *testing.T) {
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "corrupt blob content must trigger fallback")
 }
 
-// The primary replies 200 with the right sidecar count but none of the
-// sidecars carries the requested versioned hash (e.g. sidecars of another
-// block at the same slot during a reorg). Must fall back.
+// 200 with the right count but none of the sidecars carries the requested
+// hash (e.g. another fork's sidecars at the same slot) must trigger fallback.
 func TestFallbackBeacon_FallsBackOnMissingRequestedHash(t *testing.T) {
 	primary, primaryHits := newStubBeacon(t, beaconServesWrongCommitment)
 	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
@@ -213,9 +205,7 @@ func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 }
 
 // When every beacon fails to serve a valid blob, an error is returned and
-// every endpoint's failure is recorded in metrics (exercised via a real
-// *Metrics). The corrupt-content endpoint proves verification failures are
-// counted the same way as availability failures.
+// every endpoint's failure is recorded in metrics.
 func TestFallbackBeacon_AllFailReturnsError(t *testing.T) {
 	primary, primaryHits := newStubBeacon(t, beaconServesEmpty)
 	fallback, fallbackHits := newStubBeacon(t, beaconServesCorruptBlob)

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/morph-l2/go-ethereum/common"
 	"github.com/morph-l2/go-ethereum/common/hexutil"
 	"github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
@@ -96,6 +97,12 @@ func oneHash() []IndexedBlobHash {
 	return []IndexedBlobHash{{Index: 0, Hash: zeroBlobHash}}
 }
 
+// wantHashes is the verification set the caller always has (tx.BlobHashes()),
+// independent of whether index hints could be built.
+func wantHashes() []common.Hash {
+	return []common.Hash{zeroBlobHash}
+}
+
 type canceledHTTP struct {
 	calls *int32
 }
@@ -107,7 +114,7 @@ func (h canceledHTTP) Get(ctx context.Context, _ string, _ http.Header) (*http.R
 
 func fetch(t *testing.T, c *FallbackBeaconClient) (types.BlobTxSidecar, error) {
 	t.Helper()
-	return c.GetVerifiedBlobs(context.Background(), L1BlockRef{Time: 12}, oneHash())
+	return c.GetVerifiedBlobSidecar(context.Background(), L1BlockRef{Time: 12}, wantHashes(), oneHash())
 }
 
 // The primary serves the blob and the fallback is never queried.
@@ -202,6 +209,35 @@ func TestFallbackBeacon_FallsBackOnNullSidecar(t *testing.T) {
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "null sidecar must trigger fallback")
 }
 
+// The #745 self-heal: when the caller cannot build index hints (the L1 block
+// body was unavailable), it passes nil hints. The client must still fetch all
+// sidecars at the slot and authenticate them by hash — a nil hint is NOT a
+// failure. Guards against turning a BlockByNumber failure back into a hard
+// error; see the DO NOT comment in fetchRollupDataByTxHash.
+func TestFallbackBeacon_VerifiesWithoutIndexHints(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesBlob)
+
+	c := NewFallbackBeaconClient([]string{primary}, nil, nil)
+	sidecar, err := c.GetVerifiedBlobSidecar(context.Background(), L1BlockRef{Time: 12}, wantHashes(), nil)
+	require.NoError(t, err)
+	require.Len(t, sidecar.Blobs, 1)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+}
+
+// Verification stays active on the no-index fetch-all path: a corrupt primary
+// must still rotate to a healthy fallback even without index hints.
+func TestFallbackBeacon_FallsBackWithoutIndexHintsOnCorruptContent(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesCorruptBlob)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
+
+	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
+	sidecar, err := c.GetVerifiedBlobSidecar(context.Background(), L1BlockRef{Time: 12}, wantHashes(), nil)
+	require.NoError(t, err)
+	require.Len(t, sidecar.Blobs, 1)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+	require.Positive(t, atomic.LoadInt32(fallbackHits), "corrupt content must trigger fallback even without index hints")
+}
+
 func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	var primaryCalls, fallbackCalls int32
 	c := &FallbackBeaconClient{
@@ -214,7 +250,7 @@ func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	sidecars, err := c.GetVerifiedBlobs(ctx, L1BlockRef{Time: 12}, oneHash())
+	sidecars, err := c.GetVerifiedBlobSidecar(ctx, L1BlockRef{Time: 12}, wantHashes(), oneHash())
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, sidecars.Blobs)

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -267,6 +267,22 @@ func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	require.Zero(t, atomic.LoadInt32(&fallbackCalls))
 }
 
+// Every configured beacon answers 200 with an empty sidecar list (blob
+// pruned everywhere / not yet indexed): the caller must get an error, never
+// an empty sidecar as success.
+func TestFallbackBeacon_AllEmptyReturnsError(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesEmpty)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesEmpty)
+
+	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
+	sidecar, err := fetch(t, c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found in beacon response")
+	require.Empty(t, sidecar.Blobs)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+	require.Positive(t, atomic.LoadInt32(fallbackHits))
+}
+
 // When every beacon fails to serve a valid blob, an error is returned and
 // every endpoint's failure is recorded in metrics.
 func TestFallbackBeacon_AllFailReturnsError(t *testing.T) {

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -53,6 +53,7 @@ const (
 	beaconServerError                                  // 500
 	beaconServesCorruptBlob                            // 200, right count and commitment, blob bytes do not match
 	beaconServesWrongCommitment                        // 200, right count, commitment of some other blob
+	beaconServesNullSidecar                            // 200, JSON null entry in the sidecar list
 )
 
 // newStubBeacon serves the genesis + spec endpoints (needed for slot math) and
@@ -80,6 +81,8 @@ func newStubBeacon(t *testing.T, behavior beaconBehavior) (string, *int32) {
 				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0, corruptBlobHex, hexutil.Encode(zeroBlobCommitment[:])) + `]}`))
 			case beaconServesWrongCommitment:
 				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0, zeroBlobHex, hex48) + `]}`))
+			case beaconServesNullSidecar:
+				_, _ = w.Write([]byte(`{"data":[null]}`))
 			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -183,6 +186,20 @@ func TestFallbackBeacon_FallsBackOnMissingRequestedHash(t *testing.T) {
 	require.Len(t, sidecars.Blobs, 1)
 	require.Positive(t, atomic.LoadInt32(primaryHits))
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "missing requested hash must trigger fallback")
+}
+
+// A JSON null in the sidecar list decodes to a nil pointer; it must count as
+// a verification failure and trigger fallback, not panic.
+func TestFallbackBeacon_FallsBackOnNullSidecar(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesNullSidecar)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
+
+	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
+	sidecars, err := fetch(t, c)
+	require.NoError(t, err)
+	require.Len(t, sidecars.Blobs, 1)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+	require.Positive(t, atomic.LoadInt32(fallbackHits), "null sidecar must trigger fallback")
 }
 
 func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -9,30 +9,54 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/common/hexutil"
+	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	"github.com/stretchr/testify/require"
 )
 
-// zero-value but correctly-sized hex so the beacon JSON decodes into a
-// BlobSidecar. GetBlobSidecarsEnhanced does not verify blob contents (that
-// happens downstream), it only counts sidecars, so dummy bytes are fine here.
+// GetBlobSidecarsEnhanced authenticates blob content against the requested
+// versioned hashes, so the accept-path stubs must serve a real
+// (blob, commitment) pair. The all-zero blob is the cheapest valid one: its
+// KZG commitment is computed once here and its versioned hash is what tests
+// request.
 var (
 	hex32 = "0x" + strings.Repeat("00", 32)
 	hex48 = "0x" + strings.Repeat("00", 48)
+
+	zeroBlobHex        = "0x" + strings.Repeat("00", BlobSize)
+	zeroBlobCommitment = mustZeroBlobCommitment()
+	zeroBlobHash       = KZGToVersionedHash(zeroBlobCommitment)
+
+	// Valid field elements (first byte 0x01 < BLS modulus high byte) but not
+	// the zero blob, served under the zero blob's commitment: the count and
+	// the commitment lookup both pass, only the KZG round-trip in verifyBlob
+	// can catch it.
+	corruptBlobHex = "0x01" + strings.Repeat("00", BlobSize-1)
 )
 
-func sidecarJSON(index int) string {
-	return fmt.Sprintf(`{"block_root":%q,"slot":"1","blob":"0x00","index":"%d","kzg_commitment":%q,"kzg_proof":%q}`,
-		hex32, index, hex48, hex48)
+func mustZeroBlobCommitment() kzg4844.Commitment {
+	var blob Blob
+	commitment, err := kzg4844.BlobToCommitment(blob.KZGBlob())
+	if err != nil {
+		panic(err)
+	}
+	return commitment
+}
+
+func sidecarJSON(index int, blobHex, commitmentHex string) string {
+	return fmt.Sprintf(`{"block_root":%q,"slot":"1","blob":%q,"index":"%d","kzg_commitment":%q,"kzg_proof":%q}`,
+		hex32, blobHex, index, commitmentHex, hex48)
 }
 
 // beaconBehavior controls what a stub beacon returns for blob_sidecars.
 type beaconBehavior int
 
 const (
-	beaconServesBlob  beaconBehavior = iota // 200 with one sidecar
-	beaconServesEmpty                       // 200 with an empty list (pruned / not indexed)
-	beaconServerError                       // 500
+	beaconServesBlob             beaconBehavior = iota // 200 with one valid sidecar
+	beaconServesEmpty                                  // 200 with an empty list (pruned / not indexed)
+	beaconServerError                                  // 500
+	beaconServesCorruptBlob                            // 200, right count and commitment, blob bytes do not match
+	beaconServesWrongCommitment                        // 200, right count, commitment of some other blob
 )
 
 // newStubBeacon serves the genesis + spec endpoints (needed for slot math) and
@@ -51,11 +75,15 @@ func newStubBeacon(t *testing.T, behavior beaconBehavior) (string, *int32) {
 			atomic.AddInt32(&blobHits, 1)
 			switch behavior {
 			case beaconServesBlob:
-				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0) + `]}`))
+				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0, zeroBlobHex, hexutil.Encode(zeroBlobCommitment[:])) + `]}`))
 			case beaconServesEmpty:
 				_, _ = w.Write([]byte(`{"data":[]}`))
 			case beaconServerError:
 				w.WriteHeader(http.StatusInternalServerError)
+			case beaconServesCorruptBlob:
+				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0, corruptBlobHex, hexutil.Encode(zeroBlobCommitment[:])) + `]}`))
+			case beaconServesWrongCommitment:
+				_, _ = w.Write([]byte(`{"data":[` + sidecarJSON(0, zeroBlobHex, hex48) + `]}`))
 			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -66,7 +94,7 @@ func newStubBeacon(t *testing.T, behavior beaconBehavior) (string, *int32) {
 }
 
 func oneHash() []IndexedBlobHash {
-	return []IndexedBlobHash{{Index: 0, Hash: common.Hash{}}}
+	return []IndexedBlobHash{{Index: 0, Hash: zeroBlobHash}}
 }
 
 type canceledHTTP struct {
@@ -133,6 +161,37 @@ func TestFallbackBeacon_FallsBackOnTransportError(t *testing.T) {
 	require.Positive(t, atomic.LoadInt32(fallbackHits))
 }
 
+// The primary replies 200 with the right sidecar count and the right
+// commitment, but the blob bytes do not commit to the requested hash
+// (corrupted storage, wrong fork, etc.). Content verification must reject it
+// and fall back instead of handing bad bytes downstream.
+func TestFallbackBeacon_FallsBackOnCorruptBlobContent(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesCorruptBlob)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
+
+	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
+	sidecars, err := fetch(t, c)
+	require.NoError(t, err)
+	require.Len(t, sidecars, 1)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+	require.Positive(t, atomic.LoadInt32(fallbackHits), "corrupt blob content must trigger fallback")
+}
+
+// The primary replies 200 with the right sidecar count but none of the
+// sidecars carries the requested versioned hash (e.g. sidecars of another
+// block at the same slot during a reorg). Must fall back.
+func TestFallbackBeacon_FallsBackOnMissingRequestedHash(t *testing.T) {
+	primary, primaryHits := newStubBeacon(t, beaconServesWrongCommitment)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesBlob)
+
+	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, nil)
+	sidecars, err := fetch(t, c)
+	require.NoError(t, err)
+	require.Len(t, sidecars, 1)
+	require.Positive(t, atomic.LoadInt32(primaryHits))
+	require.Positive(t, atomic.LoadInt32(fallbackHits), "missing requested hash must trigger fallback")
+}
+
 func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	var primaryCalls, fallbackCalls int32
 	c := &FallbackBeaconClient{
@@ -153,11 +212,13 @@ func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	require.Zero(t, atomic.LoadInt32(&fallbackCalls))
 }
 
-// When every beacon fails to serve the blob, an error is returned and every
-// endpoint's failure is recorded in metrics (exercised via a real *Metrics).
+// When every beacon fails to serve a valid blob, an error is returned and
+// every endpoint's failure is recorded in metrics (exercised via a real
+// *Metrics). The corrupt-content endpoint proves verification failures are
+// counted the same way as availability failures.
 func TestFallbackBeacon_AllFailReturnsError(t *testing.T) {
 	primary, primaryHits := newStubBeacon(t, beaconServesEmpty)
-	fallback, fallbackHits := newStubBeacon(t, beaconServerError)
+	fallback, fallbackHits := newStubBeacon(t, beaconServesCorruptBlob)
 
 	m := PrometheusMetrics("morphnode_test_" + t.Name())
 	c := NewFallbackBeaconClient([]string{primary, fallback}, nil, m)

--- a/node/derivation/base_client_test.go
+++ b/node/derivation/base_client_test.go
@@ -238,6 +238,15 @@ func TestFallbackBeacon_FallsBackWithoutIndexHintsOnCorruptContent(t *testing.T)
 	require.Positive(t, atomic.LoadInt32(fallbackHits), "corrupt content must trigger fallback even without index hints")
 }
 
+// A client constructed with no endpoints must error instead of silently
+// returning an empty sidecar as success.
+func TestFallbackBeacon_NoEndpointsReturnsError(t *testing.T) {
+	c := NewFallbackBeaconClient(nil, nil, nil)
+	sidecar, err := c.GetVerifiedBlobSidecar(context.Background(), L1BlockRef{Time: 12}, wantHashes(), nil)
+	require.Error(t, err)
+	require.Empty(t, sidecar.Blobs)
+}
+
 func TestFallbackBeacon_StopsOnContextCancellation(t *testing.T) {
 	var primaryCalls, fallbackCalls int32
 	c := &FallbackBeaconClient{

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -210,11 +210,17 @@ func dataAndHashesFromTxs(txs types.Transactions, targetTx *types.Transaction) [
 	return hashes
 }
 
-// FallbackBeaconClient queries several beacon nodes in order for blob sidecars.
-// A beacon is skipped and the next one tried when it errors, is unreachable,
-// answers with too few sidecars, or serves blob content that fails
-// verification against the requested hashes. Failing endpoints are recorded
+// FallbackBeaconClient queries several beacon nodes in order and rotates to
+// the next one when an endpoint cannot serve verified blobs (error, missing
+// data, or content failing hash verification). Failing endpoints are recorded
 // in the beacon_request_failure_total metric.
+//
+// Scope: fallback only covers per-endpoint data faults (corruption, pruned or
+// unsynced data, client bugs). It is not a consistency mechanism and should
+// not grow into one — safety against bad data comes from the KZG hash
+// verification itself, and EL/CL fork mismatches near the chain head are
+// eliminated by running derivation with confirmations=finalized, not by
+// trying more beacons.
 type FallbackBeaconClient struct {
 	clients   []*L1BeaconClient
 	endpoints []string // parallel to clients, used only for logs/metrics

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -244,37 +244,27 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 
 // GetVerifiedBlobSidecar fetches and content-verifies the blobs identified by
 // wantHashes — the L1 tx's versioned blob hashes, in tx order — trying each
-// configured beacon in turn. It returns the assembled BlobTxSidecar (blobs +
-// commitments, in wantHashes order). A beacon that errors or serves an
-// incomplete/invalid set is recorded as a failure and skipped; if every
-// beacon fails, the last error is returned.
+// configured beacon in turn and returning the assembled BlobTxSidecar. A
+// beacon that errors or serves an incomplete/invalid set is recorded as a
+// failure and skipped; if every beacon fails, the last error is returned.
 //
-// indexHints is an optional optimization, NOT a correctness input: when
-// non-empty, the first fetch attempt asks the beacon for only those sidecar
-// indices (?indices=) instead of the whole slot. Verification is purely by
-// hash — verifyBlob re-derives each commitment from the blob bytes and checks
-// it against wantHashes — so a caller that cannot build indices (e.g. the L1
-// block body is unavailable) may pass nil and every sidecar at the slot is
-// fetched and matched by hash instead. Keeping index (a data-fetch detail)
-// and hash (the security check) apart is deliberate: conflating them is what
-// previously made a block-body fetch failure look "unverifiable" and led to
-// dropping the fetch-all self-heal.
+// indexHints is an optional fetch optimization (?indices= filter), not a
+// correctness input: verification is purely by hash, so callers that cannot
+// build indices may pass nil and the whole slot is fetched and matched.
 func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L1BlockRef, wantHashes []common.Hash, indexHints []IndexedBlobHash) (types.BlobTxSidecar, error) {
 	if len(wantHashes) == 0 {
 		return types.BlobTxSidecar{}, nil
 	}
-	// Config validation rejects an empty beacon list at startup; this guards
-	// direct construction, where falling through would silently return an
-	// empty sidecar as success.
+	// Guards direct construction; config validation already rejects an empty
+	// beacon list at startup.
 	if len(c.clients) == 0 {
 		return types.BlobTxSidecar{}, errors.New("no beacon endpoints configured")
 	}
 	var lastErr error
 	for i, cl := range c.clients {
 		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, indexHints)
-		// An empty list (slot pruned / not yet indexed) is an availability
-		// failure of this endpoint; report it as such rather than as a
-		// hash-match failure inside blobsFromSidecars.
+		// Empty list (slot pruned / not yet indexed) is an availability
+		// failure of this endpoint.
 		if err == nil && len(sidecars) == 0 {
 			err = errors.New("beacon returned no sidecars for slot")
 		}
@@ -292,7 +282,7 @@ func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L
 			c.metrics.IncBeaconRequestFailure(c.endpoints[i])
 		}
 		if c.log != nil {
-			c.log.Error("beacon failed to serve valid blob sidecars, trying next endpoint",
+			c.log.Error("beacon failed to serve blob sidecars, trying next endpoint",
 				"endpoint", c.endpoints[i], "err", err)
 		}
 		lastErr = err
@@ -322,22 +312,22 @@ func blobsFromSidecars(sidecars []*BlobSidecar, wantHashes []common.Hash) (types
 		Blobs:       make([]kzg4844.Blob, 0, len(wantHashes)),
 		Commitments: make([]kzg4844.Commitment, 0, len(wantHashes)),
 	}
-	for _, expected := range wantHashes {
+	for i, expected := range wantHashes {
 		sidecar, ok := byHash[expected]
 		if !ok {
-			return types.BlobTxSidecar{}, fmt.Errorf("blob (hash=%s) not found in beacon response", expected.Hex())
+			return types.BlobTxSidecar{}, fmt.Errorf("blob %d (hash=%s) not found in beacon sidecars", i, expected.Hex())
 		}
 		b, err := hexutil.Decode(sidecar.Blob)
 		if err != nil {
-			return types.BlobTxSidecar{}, fmt.Errorf("failed to decode blob (hash=%s): %w", expected.Hex(), err)
+			return types.BlobTxSidecar{}, fmt.Errorf("failed to decode blob %d: %w", i, err)
 		}
 		if len(b) != BlobSize {
-			return types.BlobTxSidecar{}, fmt.Errorf("blob (hash=%s): unexpected length %d (want %d)", expected.Hex(), len(b), BlobSize)
+			return types.BlobTxSidecar{}, fmt.Errorf("blob %d: unexpected length %d (want %d, hash=%s)", i, len(b), BlobSize, expected.Hex())
 		}
 		var blob Blob
 		copy(blob[:], b)
 		if err := verifyBlob(&blob, expected); err != nil {
-			return types.BlobTxSidecar{}, err
+			return types.BlobTxSidecar{}, fmt.Errorf("blob %d: %w", i, err)
 		}
 		var commitment kzg4844.Commitment
 		copy(commitment[:], sidecar.KZGCommitment[:])

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -212,13 +212,9 @@ func dataAndHashesFromTxs(txs types.Transactions, targetTx *types.Transaction) [
 
 // FallbackBeaconClient queries several beacon nodes in order for blob sidecars.
 // A beacon is skipped and the next one tried when it errors, is unreachable,
-// answers with too few sidecars, or serves blob bytes that do not commit to
-// the requested versioned hashes — a beacon that pruned the slot, has not
-// indexed it yet, or holds corrupted blob data still replies 200 with a
-// plausible-looking list, which a transport-level fallback would miss. The
-// failing endpoint is recorded in the beacon_request_failure_total metric so
-// a flaky node is visible on dashboards. With a single endpoint it behaves
-// like a bare L1BeaconClient.
+// answers with too few sidecars, or serves blob content that fails
+// verification against the requested hashes. Failing endpoints are recorded
+// in the beacon_request_failure_total metric.
 type FallbackBeaconClient struct {
 	clients   []*L1BeaconClient
 	endpoints []string // parallel to clients, used only for logs/metrics
@@ -240,13 +236,8 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 }
 
 // GetBlobSidecarsEnhanced tries each configured beacon in order and returns
-// the first response that actually carries all requested blobs: at least
-// len(hashes) sidecars (at least one when no explicit hashes are requested),
-// every requested versioned hash present among them, and each matched blob's
-// bytes authenticated against its hash via verifySidecars. A beacon that
-// errors, returns an incomplete set, or serves invalid blob content is
-// recorded as a failure and skipped, so callers never receive unverified
-// data while a healthy fallback exists. If every beacon fails, the last
+// the first response carrying all requested blobs with verified content.
+// A failing beacon is recorded and skipped; if every beacon fails, the last
 // error is returned.
 func (c *FallbackBeaconClient) GetBlobSidecarsEnhanced(ctx context.Context, ref L1BlockRef, hashes []IndexedBlobHash) ([]*BlobSidecar, error) {
 	var lastErr error
@@ -277,15 +268,9 @@ func (c *FallbackBeaconClient) GetBlobSidecarsEnhanced(ctx context.Context, ref 
 	return nil, lastErr
 }
 
-// verifySidecars checks that, for every requested versioned hash, sidecars
-// contains a blob whose bytes actually commit to that hash. Sidecars are
-// matched by the versioned hash derived from their beacon-supplied
-// commitment, then authenticated with verifyBlob's local KZG commitment
-// round-trip, so a beacon can neither omit a requested blob nor serve
-// corrupted bytes under a correct-looking commitment. Extra sidecars (e.g.
-// from a beacon that ignores the indices filter) are tolerated and simply
-// not inspected. With no requested hashes there is nothing to authenticate
-// and the response is accepted as-is.
+// verifySidecars checks that sidecars contains, for every requested hash, a
+// blob whose bytes commit to that hash (matched via the commitment-derived
+// versioned hash, authenticated by verifyBlob). Extra sidecars are ignored.
 func verifySidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) error {
 	if len(hashes) == 0 {
 		return nil

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/common/hexutil"
 	"github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	"github.com/morph-l2/go-ethereum/params"
@@ -210,13 +211,14 @@ func dataAndHashesFromTxs(txs types.Transactions, targetTx *types.Transaction) [
 }
 
 // FallbackBeaconClient queries several beacon nodes in order for blob sidecars.
-// A beacon is skipped and the next one tried when it errors, is unreachable, or
-// answers with too few sidecars — a beacon that pruned the slot or has not
-// indexed it yet still replies 200 with an empty/partial list, which is exactly
-// the "temporarily failed to fetch blob" case seen in production and which a
-// transport-level fallback would miss. The failing endpoint is recorded in the
-// beacon_request_failure_total metric so a flaky node is visible on dashboards.
-// With a single endpoint it behaves like a bare L1BeaconClient.
+// A beacon is skipped and the next one tried when it errors, is unreachable,
+// answers with too few sidecars, or serves blob bytes that do not commit to
+// the requested versioned hashes — a beacon that pruned the slot, has not
+// indexed it yet, or holds corrupted blob data still replies 200 with a
+// plausible-looking list, which a transport-level fallback would miss. The
+// failing endpoint is recorded in the beacon_request_failure_total metric so
+// a flaky node is visible on dashboards. With a single endpoint it behaves
+// like a bare L1BeaconClient.
 type FallbackBeaconClient struct {
 	clients   []*L1BeaconClient
 	endpoints []string // parallel to clients, used only for logs/metrics
@@ -237,34 +239,83 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 	}
 }
 
-// GetBlobSidecarsEnhanced tries each configured beacon in order and returns the
-// first response that actually carries the requested blobs (at least len(hashes)
-// sidecars, or at least one when no explicit hashes are requested). A beacon
-// that errors or returns an incomplete set is recorded as a failure and skipped.
-// If every beacon fails, the last error is returned.
+// GetBlobSidecarsEnhanced tries each configured beacon in order and returns
+// the first response that actually carries all requested blobs: at least
+// len(hashes) sidecars (at least one when no explicit hashes are requested),
+// every requested versioned hash present among them, and each matched blob's
+// bytes authenticated against its hash via verifySidecars. A beacon that
+// errors, returns an incomplete set, or serves invalid blob content is
+// recorded as a failure and skipped, so callers never receive unverified
+// data while a healthy fallback exists. If every beacon fails, the last
+// error is returned.
 func (c *FallbackBeaconClient) GetBlobSidecarsEnhanced(ctx context.Context, ref L1BlockRef, hashes []IndexedBlobHash) ([]*BlobSidecar, error) {
 	var lastErr error
 	for i, cl := range c.clients {
 		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, hashes)
-		if err == nil && len(sidecars) > 0 && len(sidecars) >= len(hashes) {
-			return sidecars, nil
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
+		if err == nil {
+			if len(sidecars) == 0 || len(sidecars) < len(hashes) {
+				err = fmt.Errorf("beacon returned %d sidecars, want at least %d", len(sidecars), len(hashes))
+			} else {
+				err = verifySidecars(sidecars, hashes)
+			}
 		}
 		if err == nil {
-			err = fmt.Errorf("beacon returned %d sidecars, want at least %d", len(sidecars), len(hashes))
+			return sidecars, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
 		}
 		if c.metrics != nil {
 			c.metrics.IncBeaconRequestFailure(c.endpoints[i])
 		}
 		if c.log != nil {
-			c.log.Error("beacon failed to serve blob sidecars, trying next endpoint",
+			c.log.Error("beacon failed to serve valid blob sidecars, trying next endpoint",
 				"endpoint", c.endpoints[i], "err", err)
 		}
 		lastErr = err
 	}
 	return nil, lastErr
+}
+
+// verifySidecars checks that, for every requested versioned hash, sidecars
+// contains a blob whose bytes actually commit to that hash. Sidecars are
+// matched by the versioned hash derived from their beacon-supplied
+// commitment, then authenticated with verifyBlob's local KZG commitment
+// round-trip, so a beacon can neither omit a requested blob nor serve
+// corrupted bytes under a correct-looking commitment. Extra sidecars (e.g.
+// from a beacon that ignores the indices filter) are tolerated and simply
+// not inspected. With no requested hashes there is nothing to authenticate
+// and the response is accepted as-is.
+func verifySidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+	byHash := make(map[common.Hash]*BlobSidecar, len(sidecars))
+	for _, sidecar := range sidecars {
+		var commitment kzg4844.Commitment
+		copy(commitment[:], sidecar.KZGCommitment[:])
+		byHash[KZGToVersionedHash(commitment)] = sidecar
+	}
+	for i := range hashes {
+		expected := hashes[i].Hash
+		sidecar, ok := byHash[expected]
+		if !ok {
+			return fmt.Errorf("blob (hash=%s) not found in beacon response", expected.Hex())
+		}
+		b, err := hexutil.Decode(sidecar.Blob)
+		if err != nil {
+			return fmt.Errorf("failed to decode blob (hash=%s): %w", expected.Hex(), err)
+		}
+		if len(b) != BlobSize {
+			return fmt.Errorf("blob (hash=%s): unexpected length %d (want %d)", expected.Hex(), len(b), BlobSize)
+		}
+		var blob Blob
+		copy(blob[:], b)
+		if err := verifyBlob(&blob, expected); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Note: ForceGetAllBlobs is defined in derivation.go in the same package

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -283,6 +283,11 @@ func (c *FallbackBeaconClient) GetVerifiedBlobs(ctx context.Context, ref L1Block
 func blobsFromSidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) (types.BlobTxSidecar, error) {
 	byHash := make(map[common.Hash]*BlobSidecar, len(sidecars))
 	for _, sidecar := range sidecars {
+		// JSON null entries decode to nil; skipping them surfaces as a
+		// "not found" error below instead of a panic.
+		if sidecar == nil {
+			continue
+		}
 		var commitment kzg4844.Commitment
 		copy(commitment[:], sidecar.KZGCommitment[:])
 		byHash[KZGToVersionedHash(commitment)] = sidecar

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -261,6 +262,12 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L1BlockRef, wantHashes []common.Hash, indexHints []IndexedBlobHash) (types.BlobTxSidecar, error) {
 	if len(wantHashes) == 0 {
 		return types.BlobTxSidecar{}, nil
+	}
+	// Config validation rejects an empty beacon list at startup; this guards
+	// direct construction, where falling through would silently return an
+	// empty sidecar as success.
+	if len(c.clients) == 0 {
+		return types.BlobTxSidecar{}, errors.New("no beacon endpoints configured")
 	}
 	var lastErr error
 	for i, cl := range c.clients {

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -235,26 +235,26 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 	}
 }
 
-// GetBlobSidecarsEnhanced tries each configured beacon in order and returns
-// the first response carrying all requested blobs with verified content.
-// A failing beacon is recorded and skipped; if every beacon fails, the last
-// error is returned.
-func (c *FallbackBeaconClient) GetBlobSidecarsEnhanced(ctx context.Context, ref L1BlockRef, hashes []IndexedBlobHash) ([]*BlobSidecar, error) {
+// GetVerifiedBlobs tries each configured beacon in order and returns the
+// requested blobs, content-verified and in request order. A beacon that
+// errors or serves an incomplete/invalid set is recorded as a failure and
+// skipped; if every beacon fails, the last error is returned.
+func (c *FallbackBeaconClient) GetVerifiedBlobs(ctx context.Context, ref L1BlockRef, hashes []IndexedBlobHash) (types.BlobTxSidecar, error) {
+	if len(hashes) == 0 {
+		return types.BlobTxSidecar{}, nil
+	}
 	var lastErr error
 	for i, cl := range c.clients {
 		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, hashes)
 		if err == nil {
-			if len(sidecars) == 0 || len(sidecars) < len(hashes) {
-				err = fmt.Errorf("beacon returned %d sidecars, want at least %d", len(sidecars), len(hashes))
-			} else {
-				err = verifySidecars(sidecars, hashes)
+			var verified types.BlobTxSidecar
+			verified, err = blobsFromSidecars(sidecars, hashes)
+			if err == nil {
+				return verified, nil
 			}
 		}
-		if err == nil {
-			return sidecars, nil
-		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+			return types.BlobTxSidecar{}, ctxErr
 		}
 		if c.metrics != nil {
 			c.metrics.IncBeaconRequestFailure(c.endpoints[i])
@@ -265,42 +265,50 @@ func (c *FallbackBeaconClient) GetBlobSidecarsEnhanced(ctx context.Context, ref 
 		}
 		lastErr = err
 	}
-	return nil, lastErr
+	return types.BlobTxSidecar{}, lastErr
 }
 
-// verifySidecars checks that sidecars contains, for every requested hash, a
-// blob whose bytes commit to that hash (matched via the commitment-derived
-// versioned hash, authenticated by verifyBlob). Extra sidecars are ignored.
-func verifySidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) error {
-	if len(hashes) == 0 {
-		return nil
-	}
+// blobsFromSidecars matches each requested hash to a sidecar via its
+// commitment-derived versioned hash, authenticates the blob bytes with
+// verifyBlob, and assembles the result in request (i.e. tx) order — batches
+// are decoded by concatenating blob bodies, so order matters. Extra sidecars
+// are ignored. Proofs are intentionally left empty: no consumer needs them
+// and computing them costs an extra KZG op per blob.
+func blobsFromSidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) (types.BlobTxSidecar, error) {
 	byHash := make(map[common.Hash]*BlobSidecar, len(sidecars))
 	for _, sidecar := range sidecars {
 		var commitment kzg4844.Commitment
 		copy(commitment[:], sidecar.KZGCommitment[:])
 		byHash[KZGToVersionedHash(commitment)] = sidecar
 	}
+	out := types.BlobTxSidecar{
+		Blobs:       make([]kzg4844.Blob, 0, len(hashes)),
+		Commitments: make([]kzg4844.Commitment, 0, len(hashes)),
+	}
 	for i := range hashes {
 		expected := hashes[i].Hash
 		sidecar, ok := byHash[expected]
 		if !ok {
-			return fmt.Errorf("blob (hash=%s) not found in beacon response", expected.Hex())
+			return types.BlobTxSidecar{}, fmt.Errorf("blob (hash=%s) not found in beacon response", expected.Hex())
 		}
 		b, err := hexutil.Decode(sidecar.Blob)
 		if err != nil {
-			return fmt.Errorf("failed to decode blob (hash=%s): %w", expected.Hex(), err)
+			return types.BlobTxSidecar{}, fmt.Errorf("failed to decode blob (hash=%s): %w", expected.Hex(), err)
 		}
 		if len(b) != BlobSize {
-			return fmt.Errorf("blob (hash=%s): unexpected length %d (want %d)", expected.Hex(), len(b), BlobSize)
+			return types.BlobTxSidecar{}, fmt.Errorf("blob (hash=%s): unexpected length %d (want %d)", expected.Hex(), len(b), BlobSize)
 		}
 		var blob Blob
 		copy(blob[:], b)
 		if err := verifyBlob(&blob, expected); err != nil {
-			return err
+			return types.BlobTxSidecar{}, err
 		}
+		var commitment kzg4844.Commitment
+		copy(commitment[:], sidecar.KZGCommitment[:])
+		out.Blobs = append(out.Blobs, *blob.KZGBlob())
+		out.Commitments = append(out.Commitments, commitment)
 	}
-	return nil
+	return out, nil
 }
 
 // Note: ForceGetAllBlobs is defined in derivation.go in the same package

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -241,20 +241,33 @@ func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metr
 	}
 }
 
-// GetVerifiedBlobs tries each configured beacon in order and returns the
-// requested blobs, content-verified and in request order. A beacon that
-// errors or serves an incomplete/invalid set is recorded as a failure and
-// skipped; if every beacon fails, the last error is returned.
-func (c *FallbackBeaconClient) GetVerifiedBlobs(ctx context.Context, ref L1BlockRef, hashes []IndexedBlobHash) (types.BlobTxSidecar, error) {
-	if len(hashes) == 0 {
+// GetVerifiedBlobSidecar fetches and content-verifies the blobs identified by
+// wantHashes — the L1 tx's versioned blob hashes, in tx order — trying each
+// configured beacon in turn. It returns the assembled BlobTxSidecar (blobs +
+// commitments, in wantHashes order). A beacon that errors or serves an
+// incomplete/invalid set is recorded as a failure and skipped; if every
+// beacon fails, the last error is returned.
+//
+// indexHints is an optional optimization, NOT a correctness input: when
+// non-empty, the first fetch attempt asks the beacon for only those sidecar
+// indices (?indices=) instead of the whole slot. Verification is purely by
+// hash — verifyBlob re-derives each commitment from the blob bytes and checks
+// it against wantHashes — so a caller that cannot build indices (e.g. the L1
+// block body is unavailable) may pass nil and every sidecar at the slot is
+// fetched and matched by hash instead. Keeping index (a data-fetch detail)
+// and hash (the security check) apart is deliberate: conflating them is what
+// previously made a block-body fetch failure look "unverifiable" and led to
+// dropping the fetch-all self-heal.
+func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L1BlockRef, wantHashes []common.Hash, indexHints []IndexedBlobHash) (types.BlobTxSidecar, error) {
+	if len(wantHashes) == 0 {
 		return types.BlobTxSidecar{}, nil
 	}
 	var lastErr error
 	for i, cl := range c.clients {
-		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, hashes)
+		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, indexHints)
 		if err == nil {
 			var verified types.BlobTxSidecar
-			verified, err = blobsFromSidecars(sidecars, hashes)
+			verified, err = blobsFromSidecars(sidecars, wantHashes)
 			if err == nil {
 				return verified, nil
 			}
@@ -274,13 +287,13 @@ func (c *FallbackBeaconClient) GetVerifiedBlobs(ctx context.Context, ref L1Block
 	return types.BlobTxSidecar{}, lastErr
 }
 
-// blobsFromSidecars matches each requested hash to a sidecar via its
+// blobsFromSidecars matches each wanted versioned hash to a sidecar via its
 // commitment-derived versioned hash, authenticates the blob bytes with
-// verifyBlob, and assembles the result in request (i.e. tx) order — batches
+// verifyBlob, and assembles the result in wantHashes (i.e. tx) order — batches
 // are decoded by concatenating blob bodies, so order matters. Extra sidecars
 // are ignored. Proofs are intentionally left empty: no consumer needs them
 // and computing them costs an extra KZG op per blob.
-func blobsFromSidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) (types.BlobTxSidecar, error) {
+func blobsFromSidecars(sidecars []*BlobSidecar, wantHashes []common.Hash) (types.BlobTxSidecar, error) {
 	byHash := make(map[common.Hash]*BlobSidecar, len(sidecars))
 	for _, sidecar := range sidecars {
 		// JSON null entries decode to nil; skipping them surfaces as a
@@ -293,11 +306,10 @@ func blobsFromSidecars(sidecars []*BlobSidecar, hashes []IndexedBlobHash) (types
 		byHash[KZGToVersionedHash(commitment)] = sidecar
 	}
 	out := types.BlobTxSidecar{
-		Blobs:       make([]kzg4844.Blob, 0, len(hashes)),
-		Commitments: make([]kzg4844.Commitment, 0, len(hashes)),
+		Blobs:       make([]kzg4844.Blob, 0, len(wantHashes)),
+		Commitments: make([]kzg4844.Commitment, 0, len(wantHashes)),
 	}
-	for i := range hashes {
-		expected := hashes[i].Hash
+	for _, expected := range wantHashes {
 		sidecar, ok := byHash[expected]
 		if !ok {
 			return types.BlobTxSidecar{}, fmt.Errorf("blob (hash=%s) not found in beacon response", expected.Hex())

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -272,6 +272,12 @@ func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L
 	var lastErr error
 	for i, cl := range c.clients {
 		sidecars, err := cl.GetBlobSidecarsEnhanced(ctx, ref, indexHints)
+		// An empty list (slot pruned / not yet indexed) is an availability
+		// failure of this endpoint; report it as such rather than as a
+		// hash-match failure inside blobsFromSidecars.
+		if err == nil && len(sidecars) == 0 {
+			err = errors.New("beacon returned no sidecars for slot")
+		}
 		if err == nil {
 			var verified types.BlobTxSidecar
 			verified, err = blobsFromSidecars(sidecars, wantHashes)

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -281,9 +281,13 @@ func (c *FallbackBeaconClient) GetVerifiedBlobSidecar(ctx context.Context, ref L
 		if c.metrics != nil {
 			c.metrics.IncBeaconRequestFailure(c.endpoints[i])
 		}
+		// indexHints is logged because stale hints (e.g. a reorg between the
+		// header and block fetches) make every healthy beacon fail hash
+		// matching; the hint count distinguishes that from real endpoint
+		// faults when reading beacon_request_failure_total spikes.
 		if c.log != nil {
 			c.log.Error("beacon failed to serve blob sidecars, trying next endpoint",
-				"endpoint", c.endpoints[i], "err", err)
+				"endpoint", c.endpoints[i], "indexHints", len(indexHints), "err", err)
 		}
 		lastErr = err
 	}
@@ -336,8 +340,6 @@ func blobsFromSidecars(sidecars []*BlobSidecar, wantHashes []common.Hash) (types
 	}
 	return out, nil
 }
-
-// Note: ForceGetAllBlobs is defined in derivation.go in the same package
 
 // GetBlobSidecarsEnhanced is an enhanced version of GetBlobSidecars method, combining two approaches to fetch blob data
 // If the first method fails or returns no blobs, it will try the second method

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -563,23 +563,38 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 	if len(blobHashes) > 0 {
 		d.logger.Info("Transaction contains blobs", "txHash", txHash, "blobCount", len(blobHashes))
 
-		// The block body is needed to compute blob indices; without them the
-		// beacon fallback has no hashes to verify against, so fail this
-		// attempt and let the next poll retry.
-		block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber)))
-		if err != nil {
-			return nil, fmt.Errorf("failed to get block %d for blob indices: %w", blockNumber, err)
+		// indexHints lets GetVerifiedBlobSidecar ask the beacon for only the
+		// sidecars we need (?indices=) instead of the whole slot. Building it needs the
+		// full L1 block body via BlockByNumber — a heavy fullTx=true call that
+		// can fail *persistently* for a given historical block (oversized
+		// batcher-tx bodies time out, get rate-limited, or simply aren't served
+		// by some providers) even while the lighter HeaderByNumber and
+		// TransactionByHash above succeed.
+		//
+		// So a BlockByNumber failure MUST NOT be fatal: we drop the hint and let
+		// GetVerifiedBlobSidecar fetch every sidecar at the slot and match them
+		// by hash. Verification is purely hash-based against blobHashes (the
+		// L1-signed versioned hashes), so it is exactly as safe with or without
+		// the hint. This is the #745 self-heal — DO NOT turn a BlockByNumber
+		// failure back into a hard error, it can wedge derivation on a block
+		// whose body never loads. Locked in by
+		// TestFallbackBeacon_VerifiesWithoutIndexHints.
+		var indexHints []IndexedBlobHash
+		if block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber))); err == nil {
+			indexHints = dataAndHashesFromTxs(block.Transactions(), tx)
+			d.logger.Info("Built blob index hints from block", "count", len(indexHints))
+		} else {
+			d.logger.Info("could not fetch L1 block body for blob index hints; fetching all sidecars at the slot and verifying by hash",
+				"blockNumber", blockNumber, "err", err)
 		}
-		indexedBlobHashes := dataAndHashesFromTxs(block.Transactions(), tx)
-		d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
 
-		// Blobs come back content-verified against indexedBlobHashes and in
-		// tx order; a beacon serving bad data was already rotated away.
-		sidecar, err := d.l1BeaconClient.GetVerifiedBlobs(d.ctx, L1BlockRef{
+		// Blobs come back content-verified against blobHashes and in tx order;
+		// a beacon serving bad data was already rotated away.
+		sidecar, err := d.l1BeaconClient.GetVerifiedBlobSidecar(d.ctx, L1BlockRef{
 			Time: header.Time,
-		}, indexedBlobHashes)
+		}, blobHashes, indexHints)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get blobs, continuing processing:%v", err)
+			return nil, fmt.Errorf("failed to get verified blobs for tx %s: %w", txHash.Hex(), err)
 		}
 		d.logger.Info("Fetched verified blobs", "count", len(sidecar.Blobs))
 		batch.Sidecar = sidecar

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -12,10 +12,8 @@ import (
 	"github.com/morph-l2/go-ethereum/accounts/abi"
 	"github.com/morph-l2/go-ethereum/accounts/abi/bind"
 	"github.com/morph-l2/go-ethereum/common"
-	"github.com/morph-l2/go-ethereum/common/hexutil"
 	eth "github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/crypto"
-	"github.com/morph-l2/go-ethereum/crypto/kzg4844"
 	geth "github.com/morph-l2/go-ethereum/eth"
 	"github.com/morph-l2/go-ethereum/ethclient"
 	"github.com/morph-l2/go-ethereum/ethclient/authclient"
@@ -575,77 +573,16 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 		indexedBlobHashes := dataAndHashesFromTxs(block.Transactions(), tx)
 		d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
 
-		// The fallback client only returns sidecars whose content verified
-		// against indexedBlobHashes.
-		blobSidecars, err := d.l1BeaconClient.GetBlobSidecarsEnhanced(d.ctx, L1BlockRef{
+		// Blobs come back content-verified against indexedBlobHashes and in
+		// tx order; a beacon serving bad data was already rotated away.
+		sidecar, err := d.l1BeaconClient.GetVerifiedBlobs(d.ctx, L1BlockRef{
 			Time: header.Time,
 		}, indexedBlobHashes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get blobs, continuing processing:%v", err)
 		}
-		if len(blobSidecars) > 0 {
-			// Index beacon sidecars by their KZG-derived versioned hash so we
-			// can assemble the local sidecar in the exact order the L1 tx
-			// declared its blobs. Multi-blob batches are decoded by
-			// concatenating blob bodies in tx order; any reordering here
-			// would corrupt the resulting zstd stream. The map key is
-			// derived from the beacon-supplied commitment; verifyBlob below
-			// re-derives the same hash from the actual blob bytes, so a
-			// malicious beacon cannot forge an entry by lying about the
-			// commitment.
-			byHash := make(map[common.Hash]*BlobSidecar, len(blobSidecars))
-			for _, sidecar := range blobSidecars {
-				var commitment kzg4844.Commitment
-				copy(commitment[:], sidecar.KZGCommitment[:])
-				byHash[KZGToVersionedHash(commitment)] = sidecar
-			}
-
-			// Downstream (ParseBatch) only consumes Sidecar.Blobs and
-			// Sidecar.Commitments; Proofs is intentionally left empty to
-			// avoid an extra ~O(n) KZG op per blob per batch on every
-			// sync. If a future consumer needs Proofs, compute them
-			// lazily there or call kzg4844.ComputeBlobProof here.
-			var blobTxSidecar eth.BlobTxSidecar
-			for i, expectedHash := range blobHashes {
-				sidecar, ok := byHash[expectedHash]
-				if !ok {
-					return nil, fmt.Errorf("blob %d (hash=%s) not found in beacon sidecars", i, expectedHash.Hex())
-				}
-
-				b, err := hexutil.Decode(sidecar.Blob)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode blob %d: %w", i, err)
-				}
-				// Reject malformed beacon responses up front. copy(blob[:], b)
-				// silently:
-				//   - zero-pads when len(b) < BlobSize (tail of the
-				//     zero-initialized array stays zero)
-				//   - truncates when len(b) > BlobSize (extra bytes dropped)
-				// Either case would otherwise surface later as a confusing
-				// blob-hash mismatch instead of a clear length error.
-				if len(b) != BlobSize {
-					return nil, fmt.Errorf("blob %d: unexpected length %d (want %d, hash=%s)", i, len(b), BlobSize, expectedHash.Hex())
-				}
-				var blob Blob
-				copy(blob[:], b)
-
-				if err := verifyBlob(&blob, expectedHash); err != nil {
-					return nil, fmt.Errorf("blob %d: %w", i, err)
-				}
-
-				var commitment kzg4844.Commitment
-				copy(commitment[:], sidecar.KZGCommitment[:])
-
-				d.logger.Info("Matched blob", "txOrder", i, "beaconIndex", sidecar.Index, "hash", expectedHash.Hex())
-				blobTxSidecar.Blobs = append(blobTxSidecar.Blobs, *blob.KZGBlob())
-				blobTxSidecar.Commitments = append(blobTxSidecar.Commitments, commitment)
-			}
-
-			d.logger.Info("Blob matching results", "matched", len(blobTxSidecar.Blobs), "expected", len(blobHashes))
-			batch.Sidecar = blobTxSidecar
-		} else {
-			return nil, fmt.Errorf("not matched blob,txHash:%v,blockNumber:%v", txHash, blockNumber)
-		}
+		d.logger.Info("Fetched verified blobs", "count", len(sidecar.Blobs))
+		batch.Sidecar = sidecar
 	}
 
 	rollupData, err := d.parseBatch(batch)

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -565,12 +565,9 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 	if len(blobHashes) > 0 {
 		d.logger.Info("Transaction contains blobs", "txHash", txHash, "blobCount", len(blobHashes))
 
-		// The block body is required to compute each blob's index within the
-		// block's sidecar list, and the resulting IndexedBlobHash set is what
-		// lets the beacon fallback verify blob content per endpoint. A fetch
-		// failure here is treated as fatal for this attempt: the caller's
-		// poll loop retries the whole batch next round, which is preferable
-		// to querying beacons with no hashes to authenticate against.
+		// The block body is needed to compute blob indices; without them the
+		// beacon fallback has no hashes to verify against, so fail this
+		// attempt and let the next poll retry.
 		block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get block %d for blob indices: %w", blockNumber, err)
@@ -578,9 +575,8 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 		indexedBlobHashes := dataAndHashesFromTxs(block.Transactions(), tx)
 		d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
 
-		// Fetch the batch's blobs; the fallback client only returns sidecars
-		// whose content already verified against indexedBlobHashes, rotating
-		// to the next beacon endpoint on any invalid response.
+		// The fallback client only returns sidecars whose content verified
+		// against indexedBlobHashes.
 		blobSidecars, err := d.l1BeaconClient.GetBlobSidecarsEnhanced(d.ctx, L1BlockRef{
 			Time: header.Time,
 		}, indexedBlobHashes)

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -563,40 +563,30 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 	if len(blobHashes) > 0 {
 		d.logger.Info("Transaction contains blobs", "txHash", txHash, "blobCount", len(blobHashes))
 
-		// indexHints lets GetVerifiedBlobSidecar ask the beacon for only the
-		// sidecars we need (?indices=) instead of the whole slot. Building it needs the
-		// full L1 block body via BlockByNumber — a heavy fullTx=true call that
-		// can fail *persistently* for a given historical block (oversized
-		// batcher-tx bodies time out, get rate-limited, or simply aren't served
-		// by some providers) even while the lighter HeaderByNumber and
-		// TransactionByHash above succeed.
-		//
-		// So a BlockByNumber failure MUST NOT be fatal: we drop the hint and let
-		// GetVerifiedBlobSidecar fetch every sidecar at the slot and match them
-		// by hash. Verification is purely hash-based against blobHashes (the
-		// L1-signed versioned hashes), so it is exactly as safe with or without
-		// the hint. This is the #745 self-heal — DO NOT turn a BlockByNumber
-		// failure back into a hard error, it can wedge derivation on a block
-		// whose body never loads. Locked in by
-		// TestFallbackBeacon_VerifiesWithoutIndexHints.
-		var indexHints []IndexedBlobHash
-		if block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber))); err == nil {
-			indexHints = dataAndHashesFromTxs(block.Transactions(), tx)
-			d.logger.Info("Built blob index hints from block", "count", len(indexHints))
+		// Initialize indexedBlobHashes as nil
+		var indexedBlobHashes []IndexedBlobHash
+
+		// Only try to build IndexedBlobHash array if not forcing get all blobs
+		// Try to get the block to build IndexedBlobHash array
+		block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber)))
+		if err == nil {
+			// Successfully got the block, now build IndexedBlobHash array
+			d.logger.Info("Building IndexedBlobHash array from block", "blockNumber", blockNumber)
+			indexedBlobHashes = dataAndHashesFromTxs(block.Transactions(), tx)
+			d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
 		} else {
-			d.logger.Info("could not fetch L1 block body for blob index hints; fetching all sidecars at the slot and verifying by hash",
-				"blockNumber", blockNumber, "err", err)
+			d.logger.Info("Failed to get block, will try fetching all blobs", "blockNumber", blockNumber, "error", err)
 		}
 
-		// Blobs come back content-verified against blobHashes and in tx order;
-		// a beacon serving bad data was already rotated away.
+		// Get all blobs corresponding to this timestamp, content-verified
+		// against the tx's blob hashes inside the fallback client.
 		sidecar, err := d.l1BeaconClient.GetVerifiedBlobSidecar(d.ctx, L1BlockRef{
 			Time: header.Time,
-		}, blobHashes, indexHints)
+		}, blobHashes, indexedBlobHashes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get verified blobs for tx %s: %w", txHash.Hex(), err)
+			return nil, fmt.Errorf("failed to get blobs, continuing processing:%v", err)
 		}
-		d.logger.Info("Fetched verified blobs", "count", len(sidecar.Blobs))
+		d.logger.Info("Blob matching results", "matched", len(sidecar.Blobs), "expected", len(blobHashes))
 		batch.Sidecar = sidecar
 	}
 

--- a/node/derivation/derivation.go
+++ b/node/derivation/derivation.go
@@ -565,22 +565,22 @@ func (d *Derivation) fetchRollupDataByTxHash(txHash common.Hash, blockNumber uin
 	if len(blobHashes) > 0 {
 		d.logger.Info("Transaction contains blobs", "txHash", txHash, "blobCount", len(blobHashes))
 
-		// Initialize indexedBlobHashes as nil
-		var indexedBlobHashes []IndexedBlobHash
-
-		// Only try to build IndexedBlobHash array if not forcing get all blobs
-		// Try to get the block to build IndexedBlobHash array
+		// The block body is required to compute each blob's index within the
+		// block's sidecar list, and the resulting IndexedBlobHash set is what
+		// lets the beacon fallback verify blob content per endpoint. A fetch
+		// failure here is treated as fatal for this attempt: the caller's
+		// poll loop retries the whole batch next round, which is preferable
+		// to querying beacons with no hashes to authenticate against.
 		block, err := d.l1Client.BlockByNumber(d.ctx, big.NewInt(int64(blockNumber)))
-		if err == nil {
-			// Successfully got the block, now build IndexedBlobHash array
-			d.logger.Info("Building IndexedBlobHash array from block", "blockNumber", blockNumber)
-			indexedBlobHashes = dataAndHashesFromTxs(block.Transactions(), tx)
-			d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
-		} else {
-			d.logger.Info("Failed to get block, will try fetching all blobs", "blockNumber", blockNumber, "error", err)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get block %d for blob indices: %w", blockNumber, err)
 		}
+		indexedBlobHashes := dataAndHashesFromTxs(block.Transactions(), tx)
+		d.logger.Info("Built IndexedBlobHash array", "count", len(indexedBlobHashes))
 
-		// Get all blobs corresponding to this timestamp
+		// Fetch the batch's blobs; the fallback client only returns sidecars
+		// whose content already verified against indexedBlobHashes, rotating
+		// to the next beacon endpoint on any invalid response.
 		blobSidecars, err := d.l1BeaconClient.GetBlobSidecarsEnhanced(d.ctx, L1BlockRef{
 			Time: header.Time,
 		}, indexedBlobHashes)


### PR DESCRIPTION
## Summary

Liveness fix for the beacon fallback path: **if a beacon returns the correct number of sidecars but the blob content is wrong, the fallback never switched to the next endpoint.**

The fallback client accepted any 200 response with enough sidecars. Content verification only happened downstream in `fetchRollupDataByTxHash`, whose error aborts the poll round — the next round starts from the same primary beacon, so derivation stalls on a bad endpoint forever. Safety was never at risk (downstream verification always rejected bad bytes); the bug is that the node gets stuck instead of rotating, with no metric to alert on.

### Changes

- **`beacon.go`**: the fallback client now owns blob verification, in one place. `GetVerifiedBlobSidecar(ctx, ref, wantHashes, indexHints)` tries each beacon in order and returns the assembled `BlobTxSidecar` (blobs + commitments, in tx order). Verification is purely hash-based: every hash in `wantHashes` (the L1 tx's versioned blob hashes) must be matched via the commitment-derived hash and pass a local KZG commitment round-trip (`verifyBlob`). Any failure — error, missing hash, bad bytes, nil/null sidecar entries — counts as an endpoint failure (`beacon_request_failure_total`) and rotates to the next beacon.
- **`beacon.go` scope note**: fallback only covers per-endpoint data faults; safety comes from hash verification itself, and EL/CL fork mismatches near the head are addressed by `confirmations=finalized`, not by trying more beacons.
- **`derivation.go`**: `fetchRollupDataByTxHash` drops its own match/decode/verify loop and uses the verified result, so verification runs exactly once. `wantHashes` (security input, from `tx.BlobHashes()`) is deliberately separated from `indexHints` (query optimization, needs the full block body): a `BlockByNumber` failure just drops the hint and fetches every sidecar at the slot, keeping the #745 self-heal — verification strength is identical with or without hints.
- **`base_client_test.go`**: stubs serve real KZG data (zero blob + its actual commitment); added the failure-mode tests below.

### New test coverage

- `TestFallbackBeacon_FallsBackOnCorruptBlobContent`: 200, right count, right commitment, corrupted blob bytes → must switch (the original scenario).
- `TestFallbackBeacon_FallsBackOnMissingRequestedHash`: 200, right count, but none of the sidecars carries the requested hash (e.g. another fork's sidecars at the same slot) → must switch.
- `TestFallbackBeacon_FallsBackOnNullSidecar`: JSON `null` in the sidecar list → verification failure and rotation, not a panic.
- `TestFallbackBeacon_VerifiesWithoutIndexHints` / `TestFallbackBeacon_FallsBackWithoutIndexHintsOnCorruptContent`: the no-hint fetch-all path stays fully verified and still rotates on bad content.

## Test plan

- [x] `go test ./derivation/ -count=1` passes (all existing + new tests)
- [x] `go build ./...` in `node/`
- [ ] Devnet/testnet sanity: point a node at a bad primary beacon + healthy fallback and confirm it derives through

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob sidecar retrieval by validating content and matching requested transaction hashes.
  * Added reliable fallback behavior for corrupt, missing, or null sidecar data.
  * Blob retrieval now continues when block index hints or block lookups are unavailable.
  * Verified sidecars are assembled in the requested order before processing.
  * Added clearer failure handling when no retrieval endpoints are available or all configured endpoints fail.
  * Improved cancellation handling during sidecar retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->