### PR TITLE
Feat: make block-production intervals configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ################## update dependencies ####################
 ETHEREUM_SUBMODULE_COMMIT_OR_TAG := morph-v2.2.4
 ETHEREUM_TARGET_VERSION := morph-v2.2.4
-TENDERMINT_TARGET_VERSION := v0.3.8
+TENDERMINT_TARGET_VERSION := v0.3.9
 
 
 ETHEREUM_MODULE_NAME := github.com/morph-l2/go-ethereum

--- a/bindings/go.mod
+++ b/bindings/go.mod
@@ -2,7 +2,7 @@ module morph-l2/bindings
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -2,7 +2,7 @@ module morph-l2/common
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/holiman/uint256 v1.2.4

--- a/contracts/go.mod
+++ b/contracts/go.mod
@@ -2,7 +2,7 @@ module morph-l2/contract
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/iden3/go-iden3-crypto v0.0.16

--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -221,6 +221,17 @@ func L2NodeMain(ctx *cli.Context) error {
 		if haService != nil {
 			ha = haService
 		}
+		// Sequencer block-production intervals come from flags, which own the
+		// defaults (GlobalDuration returns the flag default when unset). Applied
+		// before the node starts producing; fails fast if fast >= empty-block.
+		blockInterval := ctx.GlobalDuration(flags.SequencerBlockInterval.Name)
+		fastBlockInterval := ctx.GlobalDuration(flags.SequencerFastBlockInterval.Name)
+		if err = tmsequencer.SetBlockIntervals(blockInterval, fastBlockInterval); err != nil {
+			return fmt.Errorf("invalid sequencer block intervals: %w", err)
+		}
+		nodeConfig.Logger.Info("sequencer block intervals configured",
+			"blockInterval", blockInterval,
+			"fastBlockInterval", fastBlockInterval)
 		tmNode, err = sequencer.SetupNode(tmCfg, tmVal, executor, nodeConfig.Logger, verifier, tracker, signer, ha)
 		if err != nil {
 			return fmt.Errorf("failed to setup consensus node: %v", err)

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -215,6 +215,21 @@ var (
 		Usage:  "Unix timestamp (milliseconds) at which consensus switches to sequencer mode",
 		EnvVar: prefixEnvVar("SEQUENCER_UPGRADE_TIME"),
 	}
+	// These flags own the block-production interval defaults (single source of
+	// truth). The tendermint sequencer package carries no default, so Value must
+	// stay set here.
+	SequencerBlockInterval = cli.DurationFlag{
+		Name:   "sequencerBlockInterval",
+		Usage:  "Empty-block fallback interval: max time between blocks when the txpool is empty. Must be greater than --sequencerFastBlockInterval.",
+		EnvVar: prefixEnvVar("SEQUENCER_BLOCK_INTERVAL"),
+		Value:  2 * time.Second,
+	}
+	SequencerFastBlockInterval = cli.DurationFlag{
+		Name:   "sequencerFastBlockInterval",
+		Usage:  "Txpool polling interval: a block is produced immediately when pending txs are found. Must be less than --sequencerBlockInterval.",
+		EnvVar: prefixEnvVar("SEQUENCER_FAST_BLOCK_INTERVAL"),
+		Value:  300 * time.Millisecond,
+	}
 
 	L1SyncLagThreshold = cli.DurationFlag{
 		Name:   "l1.syncLagThreshold",
@@ -407,6 +422,8 @@ var Flags = []cli.Flag{
 	L1SequencerContractAddr,
 	L1SyncLagThreshold,
 	SequencerUpgradeTime,
+	SequencerBlockInterval,
+	SequencerFastBlockInterval,
 	SequencerPrivateKey,
 	SequencerEnclaveSignerAddr,
 	SequencerHAEnabled,

--- a/node/go.mod
+++ b/node/go.mod
@@ -2,7 +2,7 @@ module morph-l2/node
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3

--- a/node/go.sum
+++ b/node/go.sum
@@ -416,8 +416,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
-github.com/morph-l2/tendermint v0.3.8 h1:lMiHmgANcbM+htEJyAepQn9vZb/9Poa+0LQKETxN8qM=
-github.com/morph-l2/tendermint v0.3.8/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
+github.com/morph-l2/tendermint v0.3.9 h1:0jiFtMpVmVImCAFrMFTIvTX7jfJwzaQFyLQoLccP5A8=
+github.com/morph-l2/tendermint v0.3.9/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/ops/l2-genesis/go.mod
+++ b/ops/l2-genesis/go.mod
@@ -2,7 +2,7 @@ module morph-l2/morph-deployer
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/holiman/uint256 v1.2.4

--- a/ops/tools/go.mod
+++ b/ops/tools/go.mod
@@ -2,7 +2,7 @@ module morph-l2/tools
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3

--- a/ops/tools/go.sum
+++ b/ops/tools/go.sum
@@ -163,8 +163,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
-github.com/morph-l2/tendermint v0.3.8 h1:lMiHmgANcbM+htEJyAepQn9vZb/9Poa+0LQKETxN8qM=
-github.com/morph-l2/tendermint v0.3.8/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
+github.com/morph-l2/tendermint v0.3.9 h1:0jiFtMpVmVImCAFrMFTIvTX7jfJwzaQFyLQoLccP5A8=
+github.com/morph-l2/tendermint v0.3.9/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/tx-submitter/go.mod
+++ b/tx-submitter/go.mod
@@ -2,7 +2,7 @@ module morph-l2/tx-submitter
 
 go 1.24.0
 
-replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.8
+replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
 	github.com/consensys/gnark-crypto v0.16.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sequencer block intervals through command-line options.
  * Added separate settings for empty-block fallback timing and transaction-pool polling.
  * Applied configured intervals before consensus startup and displayed them in startup logs.

* **Bug Fixes**
  * Startup now reports a clear error when interval settings are invalid, preventing the node from launching with incompatible configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->