### PR TITLE
fix: oracle response-body bound, RLP length overflow guard, metrics port validation

### DIFF
--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 
 	"morph-l2/common/codec/zstd"
 
@@ -242,11 +243,22 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("declared tx size %d exceeds remaining %d bytes", size, lr.Len())
 	}
 
+	// Guard the reconstructed length against uint32 overflow before allocating.
+	// size is a uint32, so 1+sizeByteLen+size can exceed MaxUint32 and wrap to a
+	// tiny value, leaving fullTxBytes shorter than the copies below and
+	// panicking. The remaining-bytes guard above keeps this unreachable today,
+	// but computing in uint64 and rejecting overflow keeps it safe if the size
+	// type or the upstream bounds ever change.
+	fullLen := 1 + uint64(sizeByteLen) + uint64(size)
+	if fullLen > math.MaxUint32 {
+		return nil, fmt.Errorf("declared tx size %d overflows uint32 length prefix", size)
+	}
+
 	txRaw := make([]byte, size)
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err
 	}
-	fullTxBytes := make([]byte, 1+uint32(sizeByteLen)+size)
+	fullTxBytes := make([]byte, fullLen)
 	copy(fullTxBytes[:1], []byte{firstByte})
 	copy(fullTxBytes[1:1+sizeByteLen], sizeByte)
 	copy(fullTxBytes[1+sizeByteLen:], txRaw)

--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -235,10 +235,18 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	}
 	size := binary.BigEndian.Uint32(append(make([]byte, 4-len(sizeByte)), sizeByte...))
 
-	// Reject malformed lengths before allocating attacker-controlled memory.
-	// Batch decoding currently passes a *bytes.Reader, whose remaining length
-	// provides a strict upper bound for the encoded transaction payload.
-	if lr, ok := reader.(interface{ Len() int }); ok && uint64(size) > uint64(lr.Len()) {
+	// Bound the declared length against the reader's remaining bytes before
+	// allocating: a malformed prefix can declare up to ~4.29 GiB (uint32), which
+	// is both an out-of-memory vector and, unbounded, an integer-overflow panic
+	// in the buffer sizing below. Every decode path funnels through
+	// DecodeTxsFromBytes, which always passes a *bytes.Reader, so a reader that
+	// cannot report its remaining length is an unexpected caller, not a case to
+	// tolerate silently -- fail closed rather than allocate an unbounded size.
+	lr, ok := reader.(interface{ Len() int })
+	if !ok {
+		return nil, fmt.Errorf("cannot bound tx allocation: reader %T does not report remaining length", reader)
+	}
+	if uint64(size) > uint64(lr.Len()) {
 		return nil, fmt.Errorf("declared tx size %d exceeds remaining %d bytes", size, lr.Len())
 	}
 
@@ -246,12 +254,10 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err
 	}
-	// Size the buffer in uint64: 1+uint32(sizeByteLen)+size wraps when size is
-	// near MaxUint32 (e.g. a 0xffffffff length prefix), yielding a buffer
-	// shorter than the slice expressions below and panicking. The Len() guard
-	// above already bounds size to the remaining input, so this only wraps on an
-	// out-of-band reader, but computing in uint64 removes the panic outright.
-	fullTxBytes := make([]byte, 1+uint64(sizeByteLen)+uint64(size))
+	// size is now bounded by the remaining input above, so the total length is a
+	// small in-range value: the addition cannot overflow and the buffer is never
+	// shorter than the slice copies below.
+	fullTxBytes := make([]byte, 1+int(sizeByteLen)+int(size))
 	copy(fullTxBytes[:1], []byte{firstByte})
 	copy(fullTxBytes[1:1+sizeByteLen], sizeByte)
 	copy(fullTxBytes[1+sizeByteLen:], txRaw)

--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -246,7 +246,12 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err
 	}
-	fullTxBytes := make([]byte, 1+uint32(sizeByteLen)+size)
+	// Size the buffer in uint64: 1+uint32(sizeByteLen)+size wraps when size is
+	// near MaxUint32 (e.g. a 0xffffffff length prefix), yielding a buffer
+	// shorter than the slice expressions below and panicking. The Len() guard
+	// above already bounds size to the remaining input, so this only wraps on an
+	// out-of-band reader, but computing in uint64 removes the panic outright.
+	fullTxBytes := make([]byte, 1+uint64(sizeByteLen)+uint64(size))
 	copy(fullTxBytes[:1], []byte{firstByte})
 	copy(fullTxBytes[1:1+sizeByteLen], sizeByte)
 	copy(fullTxBytes[1+sizeByteLen:], txRaw)

--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -235,18 +235,10 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	}
 	size := binary.BigEndian.Uint32(append(make([]byte, 4-len(sizeByte)), sizeByte...))
 
-	// Bound the declared length against the reader's remaining bytes before
-	// allocating: a malformed prefix can declare up to ~4.29 GiB (uint32), which
-	// is both an out-of-memory vector and, unbounded, an integer-overflow panic
-	// in the buffer sizing below. Every decode path funnels through
-	// DecodeTxsFromBytes, which always passes a *bytes.Reader, so a reader that
-	// cannot report its remaining length is an unexpected caller, not a case to
-	// tolerate silently -- fail closed rather than allocate an unbounded size.
-	lr, ok := reader.(interface{ Len() int })
-	if !ok {
-		return nil, fmt.Errorf("cannot bound tx allocation: reader %T does not report remaining length", reader)
-	}
-	if uint64(size) > uint64(lr.Len()) {
+	// Reject malformed lengths before allocating attacker-controlled memory.
+	// Batch decoding currently passes a *bytes.Reader, whose remaining length
+	// provides a strict upper bound for the encoded transaction payload.
+	if lr, ok := reader.(interface{ Len() int }); ok && uint64(size) > uint64(lr.Len()) {
 		return nil, fmt.Errorf("declared tx size %d exceeds remaining %d bytes", size, lr.Len())
 	}
 
@@ -254,10 +246,7 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err
 	}
-	// size is now bounded by the remaining input above, so the total length is a
-	// small in-range value: the addition cannot overflow and the buffer is never
-	// shorter than the slice copies below.
-	fullTxBytes := make([]byte, 1+int(sizeByteLen)+int(size))
+	fullTxBytes := make([]byte, 1+uint32(sizeByteLen)+size)
 	copy(fullTxBytes[:1], []byte{firstByte})
 	copy(fullTxBytes[1:1+sizeByteLen], sizeByte)
 	copy(fullTxBytes[1+sizeByteLen:], txRaw)

--- a/common/batch/blob_test.go
+++ b/common/batch/blob_test.go
@@ -2,7 +2,6 @@ package batch
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,17 +13,6 @@ func TestExtractInnerTxFullBytesRejectsOversizedDeclaration(t *testing.T) {
 	_, err := extractInnerTxFullBytes(0xfb, reader)
 
 	require.EqualError(t, err, "declared tx size 4294967295 exceeds remaining 0 bytes")
-}
-
-func TestExtractInnerTxFullBytesRejectsReaderWithoutLen(t *testing.T) {
-	// io.MultiReader wraps the byte reader in a type that does not expose Len(),
-	// so the declared size cannot be bounded and the decode must fail closed
-	// rather than allocate an attacker-controlled length.
-	reader := io.MultiReader(bytes.NewReader([]byte{0xff, 0xff, 0xff, 0xff, 1}))
-
-	_, err := extractInnerTxFullBytes(0xfb, reader)
-
-	require.ErrorContains(t, err, "does not report remaining length")
 }
 
 func TestExtractInnerTxFullBytesAcceptsAvailablePayload(t *testing.T) {

--- a/common/batch/blob_test.go
+++ b/common/batch/blob_test.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,17 @@ func TestExtractInnerTxFullBytesRejectsOversizedDeclaration(t *testing.T) {
 	_, err := extractInnerTxFullBytes(0xfb, reader)
 
 	require.EqualError(t, err, "declared tx size 4294967295 exceeds remaining 0 bytes")
+}
+
+func TestExtractInnerTxFullBytesRejectsReaderWithoutLen(t *testing.T) {
+	// io.MultiReader wraps the byte reader in a type that does not expose Len(),
+	// so the declared size cannot be bounded and the decode must fail closed
+	// rather than allocate an attacker-controlled length.
+	reader := io.MultiReader(bytes.NewReader([]byte{0xff, 0xff, 0xff, 0xff, 1}))
+
+	_, err := extractInnerTxFullBytes(0xfb, reader)
+
+	require.ErrorContains(t, err, "does not report remaining length")
 }
 
 func TestExtractInnerTxFullBytesAcceptsAvailablePayload(t *testing.T) {

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -195,6 +195,13 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 
 	if c.VerifyMode == VerifyModeLayer1 {
 		c.MetricsPort = ctx.GlobalUint64(flags.MetricsPort.Name)
+		// Reject an out-of-range port up front: MetricsPort is a uint64, so a
+		// misconfigured value would only surface later as an invalid listen
+		// address whose ListenAndServe fails silently in the background. The
+		// default (26660) is always in range, so a valid config never trips this.
+		if c.MetricsPort == 0 || c.MetricsPort > 65535 {
+			return fmt.Errorf("--%s must be in 1..65535, got %d", flags.MetricsPort.Name, c.MetricsPort)
+		}
 	}
 
 	if ctx.GlobalIsSet(flags.DerivationReorgCheckDepth.Name) {

--- a/node/derivation/config_test.go
+++ b/node/derivation/config_test.go
@@ -90,6 +90,32 @@ func TestVerifyMode_RejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestMetricsPort_AcceptsDefaultInLayer1(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.DerivationVerifyMode.Name: VerifyModeLayer1,
+	})); err != nil {
+		t.Fatalf("layer1 with default metrics-port rejected: %v", err)
+	}
+	if cfg.MetricsPort != 26660 {
+		t.Fatalf("default metrics-port = %d, want 26660", cfg.MetricsPort)
+	}
+}
+
+func TestMetricsPort_RejectsOutOfRange(t *testing.T) {
+	cfg := DefaultConfig()
+	err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.DerivationVerifyMode.Name: VerifyModeLayer1,
+		flags.MetricsPort.Name:          "70000",
+	}))
+	if err == nil {
+		t.Fatal("out-of-range metrics-port accepted, want error")
+	}
+	if !strings.Contains(err.Error(), flags.MetricsPort.Name) {
+		t.Fatalf("error should mention %q; got: %v", flags.MetricsPort.Name, err)
+	}
+}
+
 func TestBeaconRpcList(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -126,6 +152,7 @@ func newVerifyModeTestContext(t *testing.T, values map[string]string) *cli.Conte
 	for _, f := range []cli.Flag{
 		flags.LegacyValidatorMode,
 		flags.DerivationVerifyMode,
+		flags.MetricsPort,
 		flags.L1BeaconAddr,
 		flags.L2EngineJWTSecret,
 	} {

--- a/token-price-oracle/client/cex_feed.go
+++ b/token-price-oracle/client/cex_feed.go
@@ -22,6 +22,12 @@ const (
 	okxTickerPath     = "/api/v5/market/ticker"
 )
 
+// maxResponseBodyBytes caps how much of an HTTP price response is read into memory.
+// Ticker and Hermes latest-price payloads are a few KB at most; the cap only exists
+// so a compromised or misbehaving endpoint cannot stream an unbounded body and
+// exhaust memory.
+const maxResponseBodyBytes = 1 << 20 // 1 MiB
+
 type cexPriceFetcher func(ctx context.Context, httpClient *http.Client, baseURL string, symbol string) (*big.Float, error)
 
 // CEXPriceFeed fetches token prices from a centralized exchange REST API.
@@ -243,9 +249,12 @@ func getJSONWithHeaders(ctx context.Context, httpClient *http.Client, requestURL
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(body)) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("response body exceeds %d byte limit", maxResponseBodyBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("HTTP status %d: %s", resp.StatusCode, string(body))

--- a/token-price-oracle/client/cex_feed_test.go
+++ b/token-price-oracle/client/cex_feed_test.go
@@ -100,6 +100,38 @@ func TestFetchOKXPrice(t *testing.T) {
 	}
 }
 
+func TestGetJSONRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Stream more than the cap so a compromised/misbehaving endpoint cannot
+		// force an unbounded allocation.
+		oversized := make([]byte, maxResponseBodyBytes+1)
+		w.Write(oversized)
+	}))
+	defer server.Close()
+
+	if _, err := getJSON(context.Background(), server.Client(), server.URL); err == nil {
+		t.Fatal("getJSON accepted an oversized response body, want error")
+	}
+}
+
+func TestGetJSONAcceptsBodyAtLimit(t *testing.T) {
+	payload := `{"symbol":"BTCUSDT","price":"64385.12"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(payload))
+	}))
+	defer server.Close()
+
+	body, err := getJSON(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != payload {
+		t.Fatalf("body = %q, want %q", string(body), payload)
+	}
+}
+
 func TestParseFixedStablecoinPrice(t *testing.T) {
 	price, err := parseFixedStablecoinPrice("$1.0")
 	if err != nil {


### PR DESCRIPTION
## Summary

Small, independent hardening fixes surfaced during code review, grouped into one PR.

### 1. Bound HTTP price response body (token-price-oracle)
`getJSONWithHeaders` read price responses with an unbounded `io.ReadAll`, so a compromised or misbehaving CEX/Hermes endpoint could stream an arbitrarily large body and exhaust memory (the 10s client timeout limits time, not size). Cap the read at 1 MiB via `io.LimitReader` and reject anything larger. The helper is shared by the Binance, OKX and Pyth paths, so one change covers all three; Chainlink is unaffected (on-chain RPC).

### 2. Reject RLP tx length that overflows uint32 (common/batch)
In `extractInnerTxFullBytes`, `size` is a `uint32`, so `1+sizeByteLen+size` can exceed `MaxUint32` and wrap to a tiny buffer length, leaving `fullTxBytes` shorter than the copies that follow and panicking. The `size > remaining` guard from #1028 keeps this unreachable on the current decode path (the declared length is bounded by the decompressed stream, itself bounded upstream), so this is defensive: compute the length in uint64 and reject the overflow before allocating, keeping the decoder safe if the size type or upstream bounds ever change. No behavior change on valid input.

### 3. Validate layer1 metrics port range (node)
`MetricsPort` (uint64) had no upper-bound check, so a misconfigured value (e.g. >65535) produced an invalid listen address whose metrics `ListenAndServe` failed silently in the background. Reject a port outside `1..65535` in `SetCliContext` so the misconfig fails at startup. The default (26660, matching Tendermint's instrumentation port so layer1 validators stay consistent with other node types) is always in range, so valid configs are unaffected.

## Test plan
- [x] token-price-oracle: `go build ./...`, `go vet ./client/`, `go test ./client/` (added `TestGetJSONRejectsOversizedBody`, `TestGetJSONAcceptsBodyAtLimit`)
- [x] common/batch: `CGO_ENABLED=1 go build/vet/test ./batch/` (existing `TestExtractInnerTxFullBytes*` pass)
- [x] node/derivation: `go build/vet/test ./derivation/` (added `TestMetricsPort_AcceptsDefaultInLayer1`, `TestMetricsPort_RejectsOutOfRange`)