### PR TITLE
fix: hardening fixes from code review (response body bound, RLP length guard, metrics port)

### DIFF
--- a/common/batch/blob.go
+++ b/common/batch/blob.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 
 	"morph-l2/common/codec/zstd"
 
@@ -242,11 +243,22 @@ func extractInnerTxFullBytes(firstByte byte, reader io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("declared tx size %d exceeds remaining %d bytes", size, lr.Len())
 	}
 
+	// Guard the reconstructed length against uint32 overflow before allocating.
+	// size is a uint32, so 1+sizeByteLen+size can exceed MaxUint32 and wrap to a
+	// tiny value, leaving fullTxBytes shorter than the copies below and
+	// panicking. The remaining-bytes guard above keeps this unreachable today,
+	// but computing in uint64 and rejecting overflow keeps it safe if the size
+	// type or the upstream bounds ever change.
+	fullLen := 1 + uint64(sizeByteLen) + uint64(size)
+	if fullLen > math.MaxUint32 {
+		return nil, fmt.Errorf("declared tx size %d overflows uint32 length prefix", size)
+	}
+
 	txRaw := make([]byte, size)
 	if err := binary.Read(reader, binary.BigEndian, txRaw); err != nil {
 		return nil, err
 	}
-	fullTxBytes := make([]byte, 1+uint32(sizeByteLen)+size)
+	fullTxBytes := make([]byte, fullLen)
 	copy(fullTxBytes[:1], []byte{firstByte})
 	copy(fullTxBytes[1:1+sizeByteLen], sizeByte)
 	copy(fullTxBytes[1+sizeByteLen:], txRaw)

--- a/node/derivation/beacon.go
+++ b/node/derivation/beacon.go
@@ -223,20 +223,39 @@ func dataAndHashesFromTxs(txs types.Transactions, targetTx *types.Transaction) [
 // eliminated by running derivation with confirmations=finalized, not by
 // trying more beacons.
 type FallbackBeaconClient struct {
-	clients   []*L1BeaconClient
-	endpoints []string // parallel to clients, used only for logs/metrics
+	clients []*L1BeaconClient
+	// endpoints is parallel to clients and used only for logs/metrics; entries
+	// are pre-redacted to scheme://host so credentials embedded in the
+	// configured URLs never reach the metrics endpoint or log output.
+	endpoints []string
 	log       tmlog.Logger
 	metrics   *Metrics
 }
 
+// redactBeaconEndpoint reduces a beacon URL to scheme://host for use in
+// metrics labels and logs. Hosted beacon providers commonly embed basic-auth
+// userinfo or API keys in the URL (https://user:pass@host, ?apikey=...);
+// exposing the raw string on /metrics or in aggregated logs would leak them.
+// An endpoint that does not parse as an absolute URL collapses to a
+// placeholder rather than echoing the raw string.
+func redactBeaconEndpoint(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "<invalid-endpoint>"
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
 func NewFallbackBeaconClient(endpoints []string, log tmlog.Logger, metrics *Metrics) *FallbackBeaconClient {
 	clients := make([]*L1BeaconClient, 0, len(endpoints))
+	redacted := make([]string, 0, len(endpoints))
 	for _, endpoint := range endpoints {
 		clients = append(clients, NewL1BeaconClient(NewBasicHTTPClient(endpoint, log)))
+		redacted = append(redacted, redactBeaconEndpoint(endpoint))
 	}
 	return &FallbackBeaconClient{
 		clients:   clients,
-		endpoints: endpoints,
+		endpoints: redacted,
 		log:       log,
 		metrics:   metrics,
 	}

--- a/node/derivation/beacon_test.go
+++ b/node/derivation/beacon_test.go
@@ -55,6 +55,26 @@ func TestGetBlob(t *testing.T) {
 
 }
 
+func TestRedactBeaconEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "https://beacon.example.com", "https://beacon.example.com"},
+		{"basic auth stripped", "https://user:secret@beacon.example.com:5052", "https://beacon.example.com:5052"},
+		{"api key in path and query stripped", "https://beacon.example.com/eth/key-abc123?apikey=secret", "https://beacon.example.com"},
+		{"not a url", "not a url", "<invalid-endpoint>"},
+		{"missing scheme", "beacon.example.com:5052", "<invalid-endpoint>"},
+		{"empty", "", "<invalid-endpoint>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, redactBeaconEndpoint(tc.in))
+		})
+	}
+}
+
 func testTchRollupLog(l1Client *ethclient.Client, ctx context.Context, from, to uint64) ([]eth.Log, error) {
 	RollupContractAddress := common.HexToAddress("0x511d92b63ae7471fd5239bded29b76a446698a00")
 	query := ethereum.FilterQuery{

--- a/node/derivation/config.go
+++ b/node/derivation/config.go
@@ -195,6 +195,13 @@ func (c *Config) SetCliContext(ctx *cli.Context) error {
 
 	if c.VerifyMode == VerifyModeLayer1 {
 		c.MetricsPort = ctx.GlobalUint64(flags.MetricsPort.Name)
+		// Reject an out-of-range port up front: MetricsPort is a uint64, so a
+		// misconfigured value would only surface later as an invalid listen
+		// address whose ListenAndServe fails silently in the background. The
+		// default (26660) is always in range, so a valid config never trips this.
+		if c.MetricsPort == 0 || c.MetricsPort > 65535 {
+			return fmt.Errorf("--%s must be in 1..65535, got %d", flags.MetricsPort.Name, c.MetricsPort)
+		}
 	}
 
 	if ctx.GlobalIsSet(flags.DerivationReorgCheckDepth.Name) {

--- a/node/derivation/config_test.go
+++ b/node/derivation/config_test.go
@@ -90,6 +90,32 @@ func TestVerifyMode_RejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestMetricsPort_AcceptsDefaultInLayer1(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.DerivationVerifyMode.Name: VerifyModeLayer1,
+	})); err != nil {
+		t.Fatalf("layer1 with default metrics-port rejected: %v", err)
+	}
+	if cfg.MetricsPort != 26660 {
+		t.Fatalf("default metrics-port = %d, want 26660", cfg.MetricsPort)
+	}
+}
+
+func TestMetricsPort_RejectsOutOfRange(t *testing.T) {
+	cfg := DefaultConfig()
+	err := cfg.SetCliContext(newVerifyModeTestContext(t, map[string]string{
+		flags.DerivationVerifyMode.Name: VerifyModeLayer1,
+		flags.MetricsPort.Name:          "70000",
+	}))
+	if err == nil {
+		t.Fatal("out-of-range metrics-port accepted, want error")
+	}
+	if !strings.Contains(err.Error(), flags.MetricsPort.Name) {
+		t.Fatalf("error should mention %q; got: %v", flags.MetricsPort.Name, err)
+	}
+}
+
 func TestBeaconRpcList(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -126,6 +152,7 @@ func newVerifyModeTestContext(t *testing.T, values map[string]string) *cli.Conte
 	for _, f := range []cli.Flag{
 		flags.LegacyValidatorMode,
 		flags.DerivationVerifyMode,
+		flags.MetricsPort,
 		flags.L1BeaconAddr,
 		flags.L2EngineJWTSecret,
 	} {

--- a/node/derivation/metrics.go
+++ b/node/derivation/metrics.go
@@ -134,7 +134,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: metricsSubsystem,
 			Name:      "beacon_request_failure_total",
-			Help:      "Beacon requests that failed (transport error or non-200) per endpoint, before falling back to the next configured beacon.",
+			Help:      "Beacon requests that failed (transport error, non-200, or an empty/incomplete sidecar set) per endpoint, before falling back to the next configured beacon.",
 		}, append(append([]string{}, labels...), "endpoint")),
 	}
 }

--- a/token-price-oracle/client/cex_feed.go
+++ b/token-price-oracle/client/cex_feed.go
@@ -22,6 +22,12 @@ const (
 	okxTickerPath     = "/api/v5/market/ticker"
 )
 
+// maxResponseBodyBytes caps how much of an HTTP price response is read into memory.
+// Ticker and Hermes latest-price payloads are a few KB at most; the cap only exists
+// so a compromised or misbehaving endpoint cannot stream an unbounded body and
+// exhaust memory.
+const maxResponseBodyBytes = 1 << 20 // 1 MiB
+
 type cexPriceFetcher func(ctx context.Context, httpClient *http.Client, baseURL string, symbol string) (*big.Float, error)
 
 // CEXPriceFeed fetches token prices from a centralized exchange REST API.
@@ -243,9 +249,12 @@ func getJSONWithHeaders(ctx context.Context, httpClient *http.Client, requestURL
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(body)) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("response body exceeds %d byte limit", maxResponseBodyBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("HTTP status %d: %s", resp.StatusCode, string(body))

--- a/token-price-oracle/client/cex_feed_test.go
+++ b/token-price-oracle/client/cex_feed_test.go
@@ -100,6 +100,38 @@ func TestFetchOKXPrice(t *testing.T) {
 	}
 }
 
+func TestGetJSONRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Stream more than the cap so a compromised/misbehaving endpoint cannot
+		// force an unbounded allocation.
+		oversized := make([]byte, maxResponseBodyBytes+1)
+		w.Write(oversized)
+	}))
+	defer server.Close()
+
+	if _, err := getJSON(context.Background(), server.Client(), server.URL); err == nil {
+		t.Fatal("getJSON accepted an oversized response body, want error")
+	}
+}
+
+func TestGetJSONAcceptsBodyAtLimit(t *testing.T) {
+	payload := `{"symbol":"BTCUSDT","price":"64385.12"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(payload))
+	}))
+	defer server.Close()
+
+	body, err := getJSON(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != payload {
+		t.Fatalf("body = %q, want %q", string(body), payload)
+	}
+}
+
 func TestParseFixedStablecoinPrice(t *testing.T) {
 	price, err := parseFixedStablecoinPrice("$1.0")
 	if err != nil {


### PR DESCRIPTION
## Summary

Small, independent hardening fixes surfaced during the PR code review, grouped into one PR (one commit each).

### 1. Bound HTTP price response body (token-price-oracle)
`getJSONWithHeaders` read price responses with an unbounded `io.ReadAll`, so a compromised or misbehaving CEX/Hermes endpoint could stream an arbitrarily large body and exhaust memory (the 10s client timeout limits time, not size). Cap the read at 1 MiB via `io.LimitReader` and reject anything larger. The helper is shared by the Binance, OKX and Pyth paths, so one change covers all three; Chainlink is unaffected (on-chain RPC).

### 2. Reject RLP tx length that overflows uint32 (common/batch)
In `extractInnerTxFullBytes`, `size` is a `uint32`, so `1+sizeByteLen+size` can exceed `MaxUint32` and wrap to a tiny buffer length, leaving `fullTxBytes` shorter than the copies that follow and panicking. The `size > remaining` guard from #1028 keeps this unreachable on the current decode path (the declared length is bounded by the decompressed stream, itself bounded upstream), so this is defensive: compute the length in uint64 and reject the overflow before allocating, keeping the decoder safe if the size type or upstream bounds ever change. No behavior change on valid input.

### 3. Validate layer1 metrics port range (node)
`MetricsPort` (uint64) had no upper-bound check, so a misconfigured value (e.g. >65535) produced an invalid listen address whose metrics `ListenAndServe` failed silently in the background. Reject a port outside `1..65535` in `SetCliContext` so the misconfig fails at startup. The default (26660, matching Tendermint's instrumentation port so layer1 validators stay consistent with other node types) is always in range, so valid configs are unaffected.

### 4. Redact beacon endpoint URLs in metrics labels and logs (node)
The raw `--l1.beaconrpc` strings were used verbatim as the Prometheus `endpoint` label on `beacon_request_failure_total` and in fallback error logs. Hosted beacon providers commonly embed basic-auth userinfo or API keys in the URL, so `/metrics` scraping and log aggregation could leak credentials. Reduce the values kept for observability to `scheme://host` (the actual HTTP clients still use the full URL), and align the failure counter help text with the actual failure set (which includes empty/incomplete sidecar responses, not just transport errors).

## Test plan
- [x] token-price-oracle: `go build ./...`, `go vet ./client/`, `go test ./client/` (added `TestGetJSONRejectsOversizedBody`, `TestGetJSONAcceptsBodyAtLimit`)
- [x] common/batch: `CGO_ENABLED=1 go build/vet/test ./batch/` (existing `TestExtractInnerTxFullBytes*` pass)
- [x] node/derivation: `go build/vet/test ./derivation/` (added `TestMetricsPort_AcceptsDefaultInLayer1`, `TestMetricsPort_RejectsOutOfRange`, `TestRedactBeaconEndpoint`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized transaction data from causing decoding failures or memory-related crashes.
  * Added validation to reject invalid metrics port values before startup.
  * Limited price-feed responses to 1 MiB, rejecting excessively large responses.
  * Improved detection and reporting of incomplete beacon responses.

* **Security & Privacy**
  * Beacon endpoint details in logs and metrics are now redacted, including credentials, paths, and query parameters.

* **Tests**
  * Added coverage for endpoint redaction, metrics port validation, transaction limits, and price-response size boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->