### PR TITLE
chore(deps): pin go-ethereum to released morph-v2.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ################## update dependencies ####################
-ETHEREUM_SUBMODULE_COMMIT_OR_TAG := morph-v2.2.4
-ETHEREUM_TARGET_VERSION := morph-v2.2.4
+ETHEREUM_SUBMODULE_COMMIT_OR_TAG := morph-v2.2.5
+ETHEREUM_TARGET_VERSION := morph-v2.2.5
 TENDERMINT_TARGET_VERSION := v0.3.9
 
 

--- a/bindings/go.mod
+++ b/bindings/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
-require github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+require github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect

--- a/bindings/go.sum
+++ b/bindings/go.sum
@@ -111,6 +111,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/common/go.mod
+++ b/common/go.mod
@@ -6,7 +6,7 @@ replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.
 
 require (
 	github.com/holiman/uint256 v1.2.4
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/morph-l2/morph-da-codec/bindings/codec v0.0.0-20260727095527-681727561e38
 	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a

--- a/common/go.sum
+++ b/common/go.sum
@@ -150,6 +150,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/morph-da-codec/bindings/codec v0.0.0-20260727095527-681727561e38 h1:2OIgRP51TPMlpw9E82toxu/SQzN1hlYcxpJKC9jB0cs=
 github.com/morph-l2/morph-da-codec/bindings/codec v0.0.0-20260727095527-681727561e38/go.mod h1:f6+BHrrHbRmEYplC1nmNjGdatQtMSa2CIK7CX8T1Nfc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/contracts/go.mod
+++ b/contracts/go.mod
@@ -6,7 +6,7 @@ replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.
 
 require (
 	github.com/iden3/go-iden3-crypto v0.0.16
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/contracts/go.sum
+++ b/contracts/go.sum
@@ -138,6 +138,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/node/go.mod
+++ b/node/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/mdlayher/vsock v1.2.1
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/viper v1.13.0

--- a/node/go.sum
+++ b/node/go.sum
@@ -416,6 +416,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/tendermint v0.3.9 h1:0jiFtMpVmVImCAFrMFTIvTX7jfJwzaQFyLQoLccP5A8=
 github.com/morph-l2/tendermint v0.3.9/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/ops/l2-genesis/go.mod
+++ b/ops/l2-genesis/go.mod
@@ -6,7 +6,7 @@ replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.
 
 require (
 	github.com/holiman/uint256 v1.2.4
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli v1.22.17
 )

--- a/ops/l2-genesis/go.sum
+++ b/ops/l2-genesis/go.sum
@@ -141,6 +141,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/ops/tools/go.mod
+++ b/ops/tools/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/tendermint/tendermint => github.com/morph-l2/tendermint v0.3.9
 
 require (
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/tendermint/tendermint v0.35.9
 )
 

--- a/ops/tools/go.sum
+++ b/ops/tools/go.sum
@@ -163,6 +163,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/tendermint v0.3.9 h1:0jiFtMpVmVImCAFrMFTIvTX7jfJwzaQFyLQoLccP5A8=
 github.com/morph-l2/tendermint v0.3.9/go.mod h1:qpiwqfcCB89dBYfqVJOc/HjGxDp3OdDlthgttJJYyRs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/token-price-oracle/go.mod
+++ b/token-price-oracle/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/morph-l2/remote-signer-client/go v0.0.0-20260312080033-d078d86ddbe9
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3

--- a/token-price-oracle/go.sum
+++ b/token-price-oracle/go.sum
@@ -145,6 +145,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/morph-l2/remote-signer-client/go v0.0.0-20260312080033-d078d86ddbe9 h1:d2nKLUgiEJsQmpSWEiGbsC+sZXQCM4y/3EzyXkoMM60=
 github.com/morph-l2/remote-signer-client/go v0.0.0-20260312080033-d078d86ddbe9/go.mod h1:slD6GmYEwLHn4Yj/kO8/1QF3iaYlVVAXg2ZnGr8SW/8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/tx-submitter/go.mod
+++ b/tx-submitter/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/crate-crypto/go-eth-kzg v1.4.0
 	github.com/holiman/uint256 v1.2.4
 	github.com/morph-l2/externalsign v0.3.1
-	github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3
+	github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe
 	github.com/prometheus/client_golang v1.17.0
 	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a

--- a/tx-submitter/go.sum
+++ b/tx-submitter/go.sum
@@ -163,6 +163,8 @@ github.com/morph-l2/externalsign v0.3.1 h1:UYFDZFB0L85A4rDvuwLNBiGEi0kSmg9AZ2v8Q
 github.com/morph-l2/externalsign v0.3.1/go.mod h1:b6NJ4GUiiG/gcSJsp3p8ExsIs4ZdphlrVALASnVoGJE=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3 h1:vt1tCsMO0eFZQsNnI3KRk76V52ia19Z/Zbpk92x0w3Y=
 github.com/morph-l2/go-ethereum v1.10.14-0.20260709072051-ffa95e0670a3/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe h1:dYfgE9WDq58hiU0V0LmFkr2vUesbFaexyXfvirBVuEQ=
+github.com/morph-l2/go-ethereum v1.10.14-0.20260810084402-5a13ad4d76fe/go.mod h1:nkVzHjQWCOjvukQW8ittlwX+Xz9gmVHrP7mUi7zoHTs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=


### PR DESCRIPTION
## Summary

Switch the geth dependency to the published [morph-v2.2.5](https://github.com/morph-l2/go-ethereum/releases/tag/morph-v2.2.5) release (commit `5a13ad4d76fe`), covering all three places that reference it:

- **go.mod/go.sum** — all 8 Go modules move from the pre-release pseudo-version (`20260709-ffa95e0670a3`) to `v1.10.14-0.20260810084402-5a13ad4d76fe` (pseudo-version is Go's canonical form for the non-semver `morph-v2.2.5` tag; the embedded commit is exactly the tagged one)
- **Makefile** — `ETHEREUM_SUBMODULE_COMMIT_OR_TAG` / `ETHEREUM_TARGET_VERSION` bumped from morph-v2.2.4 (stale) to morph-v2.2.5
- **go-ethereum submodule** — gitlink pointer updated from `ffa95e067` to `5a13ad4d7`

No code changes. Will be cherry-picked to `release/0.6.1` (#1035) after merging.

## Test plan
- [x] All 8 modules build in workspace mode (`go build ./...`, CGO enabled)
- [x] `node/derivation` tests pass
- [x] `common/batch` hermetic unit tests pass (network-dependent integration tests excluded)
- [x] `make submodules` checks out morph-v2.2.5

Made with [Cursor](https://cursor.com)