### PR TITLE
fix(tx-submitter): re-check submitter activity before each submit, and never rough-estimate past a revert

### DIFF
--- a/tx-submitter/mock/l1client.go
+++ b/tx-submitter/mock/l1client.go
@@ -23,6 +23,7 @@ type L1ClientWrapper struct {
 	CallContractResult []byte
 	CodeAtErr          error
 	CodeAtResult       []byte
+	EstimateGasErr     error
 	BaseFee            *big.Int
 	Header             *types.Header
 	// Track transactions and their status
@@ -191,6 +192,9 @@ func (l *L1ClientWrapper) SuggestGasTipCap(ctx context.Context) (*big.Int, error
 }
 
 func (l *L1ClientWrapper) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	if l.EstimateGasErr != nil {
+		return 0, l.EstimateGasErr
+	}
 	return 21000, nil
 }
 

--- a/tx-submitter/services/rollup.go
+++ b/tx-submitter/services/rollup.go
@@ -750,6 +750,9 @@ func (r *Rollup) handleConfirmedTx(txRecord *types.TxRecord, tx *ethtypes.Transa
 }
 
 func (r *Rollup) finalize() error {
+	if err := r.ensureActiveSubmitter(); err != nil {
+		return fmt.Errorf("skip finalize: %w", err)
+	}
 	// get last finalized
 	lastFinalized, err := r.Rollup.LastFinalizedBatchIndex(nil)
 	if err != nil {
@@ -841,7 +844,7 @@ func (r *Rollup) finalize() error {
 			"error", err,
 		)
 
-		if r.cfg.RoughEstimateGas {
+		if r.cfg.RoughEstimateGas && !utils.IsExecutionRevertErr(err) {
 			gas = r.RoughFinalizeGasEstimate()
 			log.Info("rough estimate finalize gas", "gas", gas)
 		} else {
@@ -913,6 +916,9 @@ func (r *Rollup) finalize() error {
 }
 
 func (r *Rollup) rollup() error {
+	if err := r.ensureActiveSubmitter(); err != nil {
+		return fmt.Errorf("skip rollup: %w", err)
+	}
 	if pendingN := r.pendingTxs.Len(); pendingN > int(r.cfg.MaxTxsInPendingPool) {
 		log.Info("Pending pool full",
 			"current_size", pendingN,
@@ -1009,8 +1015,9 @@ func (r *Rollup) rollup() error {
 	gas, err := r.EstimateGas(r.WalletAddr(), r.rollupAddr, calldata, gasFeeCap, tip, estimateBlobHashes, estimateBlobFeeCap)
 	if err != nil {
 		log.Warn("Estimate gas failed", "batch_index", batchIndex, "error", err)
-		// Use estimation based on L1 message count
-		if r.cfg.RoughEstimateGas {
+		// Use estimation based on L1 message count. A revert is never guessed
+		// around: the tx would be mined only to fail, burning the blob fee.
+		if r.cfg.RoughEstimateGas && !utils.IsExecutionRevertErr(err) {
 			msgcnt := utils.ParseL1MessageCnt(rpcRollupBatch.BlockContexts)
 			gas = r.RoughRollupGasEstimate(msgcnt)
 			log.Info("Using rough gas estimation",
@@ -1322,6 +1329,18 @@ func (r *Rollup) GetGasTipAndCap() (*big.Int, *big.Int, *big.Int, *ethtypes.Head
 
 // PreCheck is run before the submitter to check whether the submitter can be started
 func (r *Rollup) PreCheck() error {
+	return r.ensureActiveSubmitter()
+}
+
+// ensureActiveSubmitter reports whether the configured wallet is an active
+// submitter right now. commitBatch / commitState / finalizeBatch all carry
+// onlyActiveSubmitter, so submitting while inactive mines a reverting tx; for a
+// blob tx the blob fee is charged even on revert. A submitter can be removed,
+// slashed, priced out by a raised minimum stake, or start withdrawing at any
+// point after startup, so every submitting loop must re-check instead of
+// trusting the one-shot startup result. Callers must treat an RPC error here as
+// "do not submit" rather than assuming the wallet is still eligible.
+func (r *Rollup) ensureActiveSubmitter() error {
 	isActive, err := r.Submitter.IsActive(nil, r.WalletAddr())
 	if err != nil {
 		return fmt.Errorf("check Submitter activity: %w", err)

--- a/tx-submitter/services/rollup_submitter_activity_test.go
+++ b/tx-submitter/services/rollup_submitter_activity_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/morph-l2/go-ethereum/common/hexutil"
+	"github.com/morph-l2/go-ethereum/eth"
+	"github.com/stretchr/testify/require"
+
+	"morph-l2/tx-submitter/mock"
+)
+
+// A submitter can be removed, slashed, priced out by a raised minimum stake, or
+// start withdrawing at any time after startup. Every submitting method carries
+// onlyActiveSubmitter on L1, so the loops must re-check instead of trusting the
+// startup PreCheck: submitting while inactive mines a reverting tx, and a
+// reverting blob tx is still charged its full blob fee.
+func TestRollupSkipsWhenSubmitterBecameInactive(t *testing.T) {
+	r, _, _, _ := setupTestRollup(t)
+	r.Submitter.(*mock.MockSubmitter).SetActive(r.WalletAddr(), false)
+
+	require.ErrorContains(t, r.rollup(), "not an active submitter")
+	require.Zero(t, r.pendingTxs.Len())
+}
+
+func TestFinalizeSkipsWhenSubmitterBecameInactive(t *testing.T) {
+	r, _, _, rollupContract := setupTestRollup(t)
+	rollupContract.SetLastFinalizedBatchIndex(big.NewInt(10))
+	rollupContract.SetLastCommittedBatchIndex(big.NewInt(12))
+	r.Submitter.(*mock.MockSubmitter).SetActive(r.WalletAddr(), false)
+
+	require.ErrorContains(t, r.finalize(), "not an active submitter")
+	require.Zero(t, r.pendingTxs.Len())
+}
+
+// An RPC failure on the activity probe must also stop submission: assuming the
+// wallet is still eligible is what burns funds.
+func TestRollupSkipsWhenActivityProbeFails(t *testing.T) {
+	r, _, _, _ := setupTestRollup(t)
+	r.Submitter.(*mock.MockSubmitter).SetError(errors.New("rpc unavailable"))
+
+	require.ErrorContains(t, r.rollup(), "check Submitter activity")
+	require.Zero(t, r.pendingTxs.Len())
+}
+
+// RoughEstimateGas exists to survive a flaky eth_estimateGas, not to paper over a
+// contract revert. Guessing a gas limit past a revert submits a tx that can only
+// fail, so the revert must abort submission even with the flag on.
+func TestFinalizeDoesNotRoughEstimatePastRevert(t *testing.T) {
+	r, l1Mock, _, rollupContract := setupTestRollup(t)
+	r.cfg.RoughEstimateGas = true
+	rollupContract.SetLastFinalizedBatchIndex(big.NewInt(10))
+	rollupContract.SetLastCommittedBatchIndex(big.NewInt(12))
+	rollupContract.SetBatchExists(true)
+	rollupContract.SetBatchInsideChallengeWindow(false)
+	r.batchCacheLegacy.Set(12, &eth.RPCRollupBatch{
+		ParentBatchHeader: hexutil.Bytes{0x01, 0x02},
+	})
+
+	l1Mock.EstimateGasErr = errors.New("execution reverted: only active submitter allowed")
+	require.ErrorContains(t, r.finalize(), "estimate finalize gas error")
+	require.Zero(t, r.pendingTxs.Len())
+
+	// A transport-level failure still gets the rough fallback, so the flag keeps
+	// doing what it was added for.
+	l1Mock.EstimateGasErr = errors.New("connection refused")
+	require.NoError(t, r.finalize())
+	require.Equal(t, 1, r.pendingTxs.Len())
+}

--- a/tx-submitter/utils/errors.go
+++ b/tx-submitter/utils/errors.go
@@ -36,3 +36,28 @@ func IsRpcErr(err error) bool {
 	}
 	return false
 }
+
+// revertErrTargets are the eth_estimateGas failures that mean the node
+// simulated the call and the contract rejected it.
+var revertErrTargets = []string{
+	"execution reverted",
+	"always failing transaction",
+}
+
+// IsExecutionRevertErr reports whether an eth_estimateGas failure came from the
+// contract rejecting the call rather than from a transport or liveness problem.
+// A revert does not go away by guessing a gas limit: submitting anyway mines a
+// failing transaction, and for a blob tx the blob fee is charged in full even
+// though execution reverted.
+func IsExecutionRevertErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, target := range revertErrTargets {
+		if strings.Contains(msg, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/tx-submitter/utils/errors_test.go
+++ b/tx-submitter/utils/errors_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExecutionRevertErr(t *testing.T) {
+	require.False(t, IsExecutionRevertErr(nil))
+	require.False(t, IsExecutionRevertErr(errors.New("connection refused")))
+	require.False(t, IsExecutionRevertErr(errors.New("timeout")))
+	require.True(t, IsExecutionRevertErr(errors.New("execution reverted: only active submitter allowed")))
+	require.True(t, IsExecutionRevertErr(errors.New("Execution Reverted")))
+	require.True(t, IsExecutionRevertErr(errors.New("always failing transaction")))
+}


### PR DESCRIPTION
## Problem

`commitBatch` / `commitState` / `finalizeBatch` all carry `onlyActiveSubmitter`
([`Rollup.sol:119-120`](../blob/main/contracts/contracts/l1/rollup/Rollup.sol#L119), applied at `:257`, `:275`, `:598`),
but tx-submitter probed activity exactly once — `PreCheck()` at `Start()`
(`rollup.go:148`). The `rollup()` and `finalize()` loops then submitted forever
against that stale startup result.

A submitter can leave the active set at any point after startup:
`removeSubmitter` (`Submitter.sol:83`), self-service `withdraw()` (`:120`),
`slash` after a successful challenge (`:146`), or `setMinimumStake` raising the
bar (`:92`).

With `rough_estimate_gas` enabled this is a funds leak, not just a stall:

1. `eth_estimateGas` fails on the revert.
2. The rough fallback swallowed that failure and guessed a gas limit
   (`rollup.go:1013`, `:844`).
3. The tx was signed and sent anyway, and reverted on-chain.

A revert refunds unused *execution* gas, but a `commitBatch` blob tx
(`createBlobTx`, `rollup.go:1088`) is charged its **full blob fee** regardless of
whether execution reverted — that is the real drain.

Nothing broke the cycle. The failed receipt only produces a `log.Warn`
(`rollup.go:696-706`); after 6 confirmations the tx leaves the pending pool
(`rollup.go:421`), the loop re-derives the same `batchIndex` (`rollup.go:923-931`)
and resends. `MaxTxsInPendingPool` caps in-flight txs, not cumulative attempts,
and wallet balance is only exported as a metric — there is no low-balance guard.

## Fix

- Extract `ensureActiveSubmitter()` and call it at the top of `rollup()` and
  `finalize()`. An RPC failure on the probe also stops submission, rather than
  assuming the wallet is still eligible.
- Gate both rough-estimate fallbacks on a new `utils.IsExecutionRevertErr`, so
  the flag still does what it was added for (flaky / unreachable node) but never
  guesses past a contract rejection.

The added per-tick `eth_call` is one extra read per rollup/finalize interval.

## Tests

`tx-submitter/services/rollup_submitter_activity_test.go`,
`tx-submitter/utils/errors_test.go`. Each new test was confirmed to fail with the
fix reverted. `go test ./tx-submitter/...` passes.

`mock.L1ClientWrapper` gains an `EstimateGasErr` field so the estimate-failure
paths are reachable from tests.

## Note on the second audit finding

The same audit reported, at LOW, that `InitAndSyncFromDatabase`'s committed-window
loop validates middle batches only against the persisted `Hash` field without
independently recomputing `header.Hash()`. **On verification this is a false
positive and no change is included for it.**

`LoadAllSealedBatchesAndHeader` — the first step of `InitAndSyncFromDatabase` —
already re-hashes *every* loaded header and compares it to that batch's persisted
`Hash` (`common/batch/batch_storage.go:209-221`). Composed with the window loop's
`batches[i].Hash == CommittedBatches(i)`, this yields
`keccak(headers[i]) == CommittedBatches(i)` across the whole committed window.
There is no gap, and adding a second re-hash in `batch_cache.go` would be dead
weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions are no longer submitted when the configured wallet is inactive.
  * Activity-check failures now stop submission instead of proceeding.
  * Contract-reverted gas estimates are no longer bypassed with rough estimates.
  * Rough gas estimation remains available for non-revert estimation failures.
* **Tests**
  * Added coverage for inactive submitters, activity-check errors, and gas-estimation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->