### PR TITLE
feat: adjust snapshot interval, reduce the amount of raft log replay

### DIFF
--- a/node/hakeeper/config.go
+++ b/node/hakeeper/config.go
@@ -67,8 +67,8 @@ func DefaultConfig() *Config {
 			ListenPort: 9400,
 		},
 		Snapshot: SnapshotConfig{
-			Interval:     120 * time.Second,
-			Threshold:    8192,
+			Interval:     30 * time.Second,
+			Threshold:    200,
 			TrailingLogs: 1200,
 		},
 		Timeout: TimeoutConfig{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Snapshots are now created more frequently, with the interval reduced to 30 seconds.
  * The snapshot threshold has been lowered to 200.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->