### PR TITLE
feat: adjust retry client timeout to 1min on sequencer node

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -140,6 +140,14 @@ func L2NodeMain(ctx *cli.Context) error {
 		return fmt.Errorf("failed to init L1 sequencer components: %w", err)
 	}
 
+	// Nodes that can produce blocks must fail fast on a stuck geth. Set before the
+	// executor and derivation clients are built, since both read this at construction.
+	if signer != nil {
+		types.GethRetryMaxElapsedTime = types.GethRetryMaxElapsedTimeSequencer
+	}
+	nodeConfig.Logger.Info("geth retry window configured",
+		"maxElapsed", types.GethRetryMaxElapsedTime, "isSequencer", signer != nil)
+
 	// ========== Executor + sequencer / mock ==========
 	tmCfg, err := sequencer.LoadTmConfig(ctx, home)
 	if err != nil {

--- a/node/types/retryable_client.go
+++ b/node/types/retryable_client.go
@@ -38,10 +38,20 @@ const (
 	InvalidNextL1MsgIndexError = "invalid block.NextL1MsgIndex"
 
 	// Geth connection retry settings
-	GethRetryAttempts       = 60              // max retry attempts
-	GethRetryInterval       = 5 * time.Second // interval between retries
-	GethRetryMaxElapsedTime = 30 * time.Minute
+	GethRetryAttempts = 60              // max retry attempts
+	GethRetryInterval = 5 * time.Second // interval between retries
 )
+
+// GethRetryMaxElapsedTime bounds how long a geth call is retried before giving up.
+// Sequencer nodes lower it to GethRetryMaxElapsedTimeSequencer at boot (see
+// cmd/node/main.go) so a stuck geth surfaces to consensus quickly instead of
+// stalling block production; fullnodes keep the long window because they only
+// need to catch up eventually.
+var GethRetryMaxElapsedTime = 30 * time.Minute
+
+// GethRetryMaxElapsedTimeSequencer is the window used by nodes that can produce
+// blocks (i.e. a signer is configured).
+const GethRetryMaxElapsedTimeSequencer = 1 * time.Minute
 
 type RetryableClient struct {
 	authClient *authclient.Client


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sequencer nodes now use a shorter one-minute retry window when connecting to Geth.
  * Non-sequencer nodes retain the existing 30-minute retry window.
  * Startup logs now report the configured retry window and whether the node is operating as a sequencer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->