### PR TITLE
fix(devnet): scope the ha-el reth overrides, and keep .claude out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 prover/
 .git/
+.claude/
 contracts/node_modules/
 gas-oracle/app/target/
 node/build/

--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,10 @@ export MORPH_RETH_RUSTFLAGS
 export MORPH_RETH_DOCKER_TARGET
 export MORPH_RETH_ENTRYPOINT
 DEVNET_COMPOSE_FILES := -f docker-compose-devnet.yml
-DEVNET_CLEAN_COMPOSE_FILES := -f docker-compose-devnet.yml -f docker-compose-cluster.yml -f docker-compose-reth.yml
+DEVNET_CLEAN_COMPOSE_FILES := -f docker-compose-devnet.yml -f docker-compose-cluster.yml -f docker-compose-reth.yml -f docker-compose-cluster-reth.yml
 
 # The cluster topology is layered before the execution-client override, so that
-# docker-compose-reth.yml has the last word on the ha-el-* image, entrypoint and
+# the reth files have the last word on the ha-el-* image, entrypoint and
 # command. Swapping these two leaves the cluster nodes running geth even when
 # reth was asked for, because later -f files win.
 ifneq ($(DEVNET_CLUSTER_ENABLED),)
@@ -175,6 +175,11 @@ ifeq ($(EXECUTION_CLIENT),geth)
 DEVNET_EXECUTION_DEPS := submodules
 else ifeq ($(EXECUTION_CLIENT),reth)
 DEVNET_COMPOSE_FILES += -f docker-compose-reth.yml
+# The ha-el-* reth overrides are kept out of docker-compose-reth.yml because
+# compose starts any service a later -f file introduces, cluster or not.
+ifneq ($(DEVNET_CLUSTER_ENABLED),)
+DEVNET_COMPOSE_FILES += -f docker-compose-cluster-reth.yml
+endif
 ifeq ($(MORPH_RETH_BUILD_FROM_SOURCE),true)
 DEVNET_EXECUTION_DEPS := reth
 else

--- a/ops/README.md
+++ b/ops/README.md
@@ -89,10 +89,17 @@ looking anywhere else.
 `ha-node` admin API: `9501` / `9601` / `9701`.
 
 The execution-layer services are named `el` rather than `geth` because either
-client can back them: `docker-compose-cluster.yml` defines them as geth, and
-`docker-compose-reth.yml` overrides them to reth. That override only works
-because the cluster file is layered *before* the reth file — later `-f` files
-win, so the reverse order silently leaves the cluster on geth.
+client can back them: `docker-compose-cluster.yml` defines `ha-el-*` as geth,
+and `docker-compose-cluster-reth.yml` overrides them to reth. That override only
+works because the cluster file is layered *before* the reth files — later `-f`
+files win, so the reverse order silently leaves the cluster on geth.
+
+The `ha-el-*` reth overrides need their own file rather than a section of
+`docker-compose-reth.yml`: compose starts every service a later `-f` file
+introduces, whether or not an earlier file declared it, so overrides living in
+the shared reth file also came up in the non-cluster devnet — without the
+`/genesis.json` and `/jwt-secret.txt` mounts that only the cluster file
+provides, which made them exit with `Invalid value '/genesis.json' for --chain`.
 
 ## Execution-layer peering
 

--- a/ops/devnet-morph/devnet/__init__.py
+++ b/ops/devnet-morph/devnet/__init__.py
@@ -67,13 +67,19 @@ def compose_file_args(execution_client, cluster=False):
     """Return docker-compose -f flags for the chosen L2 execution client."""
     args = ['-f', 'docker-compose-devnet.yml']
     # The cluster topology comes before the execution-client override so that
-    # docker-compose-reth.yml gets the last word on the ha-el-* image,
-    # entrypoint and command. Later -f files win, so reversing these two leaves
-    # the cluster nodes on geth even when reth was requested.
+    # the reth files get the last word on the ha-el-* image, entrypoint and
+    # command. Later -f files win, so reversing these two leaves the cluster
+    # nodes on geth even when reth was requested.
     if cluster:
         args.extend(['-f', 'docker-compose-cluster.yml'])
     if execution_client == 'reth':
         args.extend(['-f', 'docker-compose-reth.yml'])
+        # The ha-el-* reth overrides sit in their own file: compose starts any
+        # service a later -f file introduces, so parking them in
+        # docker-compose-reth.yml started them in the non-cluster devnet too,
+        # without the mounts that only the cluster file supplies.
+        if cluster:
+            args.extend(['-f', 'docker-compose-cluster-reth.yml'])
     return args
 
 

--- a/ops/devnet-morph/tests/test_devnet_config.py
+++ b/ops/devnet-morph/tests/test_devnet_config.py
@@ -43,7 +43,9 @@ class DevnetConfigTest(unittest.TestCase):
         makefile = (REPO_ROOT / "Makefile").read_text()
 
         self.assertIn(
-            "DEVNET_CLEAN_COMPOSE_FILES := -f docker-compose-devnet.yml -f docker-compose-cluster.yml -f docker-compose-reth.yml",
+            "DEVNET_CLEAN_COMPOSE_FILES := -f docker-compose-devnet.yml "
+            "-f docker-compose-cluster.yml -f docker-compose-reth.yml "
+            "-f docker-compose-cluster-reth.yml",
             makefile,
         )
         self.assertIn("docker compose $(DEVNET_CLEAN_COMPOSE_FILES) down --volumes --remove-orphans", makefile)
@@ -152,14 +154,47 @@ class DevnetConfigTest(unittest.TestCase):
         for service, key in (
             ("morph-el-0", "nodekey0"),
             ("morph-el-1", "nodekey1"),
+        ):
+            self.assertIn(f"{service}:", compose)
+            self.assertIn(f'"${{PWD}}/{key}:/p2p-secret.key"', compose)
+        self.assertEqual(compose.count("--p2p-secret-key=/p2p-secret.key"), 2)
+        self.assertEqual(compose.count("--trusted-peers="), 2)
+
+    def test_reth_compose_leaves_cluster_services_to_the_cluster_reth_file(self):
+        """compose starts every service a later -f file introduces, even one no
+        earlier file declared. ha-el-* overrides parked in the shared reth file
+        therefore came up in the non-cluster devnet as well, missing the
+        /genesis.json and /jwt-secret.txt mounts that only
+        docker-compose-cluster.yml supplies, and exited with
+        "Invalid value '/genesis.json' for --chain"."""
+        compose = (DOCKER_DIR / "docker-compose-reth.yml").read_text()
+
+        for service in ("ha-el-0", "ha-el-1", "ha-el-2"):
+            self.assertNotIn(f"{service}:", compose)
+        for key in ("ha-nodekey0", "ha-nodekey1", "ha-nodekey2"):
+            self.assertNotIn(key, compose)
+
+    def test_cluster_reth_compose_overrides_the_ha_execution_clients(self):
+        cluster_reth = DOCKER_DIR / "docker-compose-cluster-reth.yml"
+
+        self.assertTrue(cluster_reth.exists())
+        compose = cluster_reth.read_text()
+
+        self.assertIn("${MORPH_RETH_IMAGE:-ghcr.io/morph-l2/morph-reth:latest}", compose)
+        self.assertIn("${MORPH_RETH_ENTRYPOINT:-/usr/local/bin/morph-reth}", compose)
+        for service, key in (
             ("ha-el-0", "ha-nodekey0"),
             ("ha-el-1", "ha-nodekey1"),
             ("ha-el-2", "ha-nodekey2"),
         ):
             self.assertIn(f"{service}:", compose)
             self.assertIn(f'"${{PWD}}/{key}:/p2p-secret.key"', compose)
-        self.assertEqual(compose.count("--p2p-secret-key=/p2p-secret.key"), 5)
-        self.assertEqual(compose.count("--trusted-peers="), 5)
+        self.assertEqual(compose.count("--p2p-secret-key=/p2p-secret.key"), 3)
+        self.assertEqual(compose.count("--trusted-peers="), 3)
+        # Nothing here may redefine the plain devnet's execution clients, or
+        # they would be reconfigured only in cluster mode.
+        for service in ("morph-el-0:", "morph-el-1:"):
+            self.assertNotIn(f"  {service}", compose)
 
     def test_execution_client_keys_have_no_trailing_newline(self):
         """reth rejects a key file with a trailing newline ("malformed or
@@ -209,6 +244,8 @@ class DevnetConfigTest(unittest.TestCase):
             sys.path.remove(str(DEVNET_PACKAGE))
 
         self.assertEqual(devnet.compose_file_args("geth"), ["-f", "docker-compose-devnet.yml"])
+        # The ha-el-* reth overrides must not reach the non-cluster devnet:
+        # compose would start those services without the cluster's mounts.
         self.assertEqual(
             devnet.compose_file_args("reth"),
             ["-f", "docker-compose-devnet.yml", "-f", "docker-compose-reth.yml"],
@@ -229,6 +266,8 @@ class DevnetConfigTest(unittest.TestCase):
                 "docker-compose-cluster.yml",
                 "-f",
                 "docker-compose-reth.yml",
+                "-f",
+                "docker-compose-cluster-reth.yml",
             ],
         )
 

--- a/ops/devnet-morph/tests/test_devnet_config.py
+++ b/ops/devnet-morph/tests/test_devnet_config.py
@@ -17,6 +17,10 @@ class DevnetConfigTest(unittest.TestCase):
             "gas-oracle/app/target/",
             "node/build/",
             "ops/docker/.devnet/",
+            # Claude Code keeps its worktrees here; on a machine that has used
+            # one, this is the single largest directory in the repo and every
+            # image build would ship it as build context.
+            ".claude/",
         ):
             self.assertIn(generated_path, dockerignore)
 

--- a/ops/docker/docker-compose-cluster-reth.yml
+++ b/ops/docker/docker-compose-cluster-reth.yml
@@ -1,0 +1,97 @@
+# reth overrides for the HA cluster's execution clients, layered on top of
+# docker-compose-cluster.yml, which defines ha-el-* as geth.
+#
+# These live in their own file rather than in docker-compose-reth.yml because
+# compose creates any service a later -f file introduces, whether or not an
+# earlier file declared it. Keeping the ha-el-* overrides in the reth file made
+# them appear in the non-cluster devnet too, where they started without the
+# /genesis.json and /jwt-secret.txt mounts that only the cluster file provides
+# and died with "Invalid value '/genesis.json' for --chain". So this file is
+# passed only when both --cluster and reth are asked for.
+#
+# See docker-compose-reth.yml for why discovery is off, why every node is handed
+# a fixed --p2p-secret-key, and how the enodes below were derived. Peering here
+# mirrors static-nodes-cluster.json: each ha-el-* dials the other two plus both
+# morph-el-*.
+#
+# The command list is spelled out per service because --trusted-peers takes one
+# comma separated value and YAML cannot concatenate an anchor with extra items.
+
+x-reth-service: &reth-service
+  image: ${MORPH_RETH_IMAGE:-ghcr.io/morph-l2/morph-reth:latest}
+  user: "0:0"
+  entrypoint:
+    - ${MORPH_RETH_ENTRYPOINT:-/usr/local/bin/morph-reth}
+
+services:
+  ha-el-0:
+    <<: *reth-service
+    command:
+      - node
+      - --chain=/genesis.json
+      - --datadir=/db
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.port=8545
+      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --ws
+      - --ws.addr=0.0.0.0
+      - --ws.port=8546
+      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8551
+      - --authrpc.jwtsecret=/jwt-secret.txt
+      - --nat=none
+      - --disable-discovery
+      - --p2p-secret-key=/p2p-secret.key
+      - --trusted-peers=enode://73edbabab8727eba67dd5c2964c610decf28ec73e72d5bc395cc5be3c61ebd76cf72ada700b10926c3d2f9e86d64fafb92c6d02deb48c16439040b7c37f86c2d@ha-el-1:30303,enode://4a1a481e53b57ea351a08d945443cdff9cb7911e9121e8240efa99e4214582c0e383a30706349ce1be88b81d0f6344c401823a6624569e20d26880774279c41c@ha-el-2:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
+    volumes:
+      - "${PWD}/ha-nodekey0:/p2p-secret.key"
+
+  ha-el-1:
+    <<: *reth-service
+    command:
+      - node
+      - --chain=/genesis.json
+      - --datadir=/db
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.port=8545
+      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --ws
+      - --ws.addr=0.0.0.0
+      - --ws.port=8546
+      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8551
+      - --authrpc.jwtsecret=/jwt-secret.txt
+      - --nat=none
+      - --disable-discovery
+      - --p2p-secret-key=/p2p-secret.key
+      - --trusted-peers=enode://343bbe0507fd72946e8d57d5b42630dc905aed7e512945eb2dfd99a0d27bb1c7e84ba621c3408242d713a972a581374ea83a4d134651c373c4f2e8425ba99857@ha-el-0:30303,enode://4a1a481e53b57ea351a08d945443cdff9cb7911e9121e8240efa99e4214582c0e383a30706349ce1be88b81d0f6344c401823a6624569e20d26880774279c41c@ha-el-2:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
+    volumes:
+      - "${PWD}/ha-nodekey1:/p2p-secret.key"
+
+  ha-el-2:
+    <<: *reth-service
+    command:
+      - node
+      - --chain=/genesis.json
+      - --datadir=/db
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.port=8545
+      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --ws
+      - --ws.addr=0.0.0.0
+      - --ws.port=8546
+      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8551
+      - --authrpc.jwtsecret=/jwt-secret.txt
+      - --nat=none
+      - --disable-discovery
+      - --p2p-secret-key=/p2p-secret.key
+      - --trusted-peers=enode://343bbe0507fd72946e8d57d5b42630dc905aed7e512945eb2dfd99a0d27bb1c7e84ba621c3408242d713a972a581374ea83a4d134651c373c4f2e8425ba99857@ha-el-0:30303,enode://73edbabab8727eba67dd5c2964c610decf28ec73e72d5bc395cc5be3c61ebd76cf72ada700b10926c3d2f9e86d64fafb92c6d02deb48c16439040b7c37f86c2d@ha-el-1:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
+    volumes:
+      - "${PWD}/ha-nodekey2:/p2p-secret.key"

--- a/ops/docker/docker-compose-reth.yml
+++ b/ops/docker/docker-compose-reth.yml
@@ -9,8 +9,10 @@
 # keys below are derived from those same files.
 #
 # Peering mirrors the geth static-nodes layout: morph-el-0 and morph-el-1 know
-# only each other, while the HA nodes dial both of them and each other. That
-# keeps ha-el-* out of the non-cluster setup, where those names do not resolve.
+# only each other. The ha-el-* overrides live in docker-compose-cluster-reth.yml
+# instead of here, because compose creates every service a later -f file names,
+# so overrides parked in this file would also start in the non-cluster devnet,
+# where the cluster's mounts are absent and those hostnames do not resolve.
 #
 # The command list is spelled out per service because --trusted-peers takes one
 # comma separated value and YAML cannot concatenate an anchor with extra items.
@@ -70,78 +72,3 @@ services:
       - --trusted-peers=enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303
     volumes:
       - "${PWD}/nodekey1:/p2p-secret.key"
-
-  # The ha-el-* overrides below only take effect when
-  # docker-compose-cluster.yml is passed as well; otherwise these services do
-  # not exist and compose ignores them.
-  ha-el-0:
-    <<: *reth-service
-    command:
-      - node
-      - --chain=/genesis.json
-      - --datadir=/db
-      - --http
-      - --http.addr=0.0.0.0
-      - --http.port=8545
-      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --ws
-      - --ws.addr=0.0.0.0
-      - --ws.port=8546
-      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.port=8551
-      - --authrpc.jwtsecret=/jwt-secret.txt
-      - --nat=none
-      - --disable-discovery
-      - --p2p-secret-key=/p2p-secret.key
-      - --trusted-peers=enode://73edbabab8727eba67dd5c2964c610decf28ec73e72d5bc395cc5be3c61ebd76cf72ada700b10926c3d2f9e86d64fafb92c6d02deb48c16439040b7c37f86c2d@ha-el-1:30303,enode://4a1a481e53b57ea351a08d945443cdff9cb7911e9121e8240efa99e4214582c0e383a30706349ce1be88b81d0f6344c401823a6624569e20d26880774279c41c@ha-el-2:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
-    volumes:
-      - "${PWD}/ha-nodekey0:/p2p-secret.key"
-
-  ha-el-1:
-    <<: *reth-service
-    command:
-      - node
-      - --chain=/genesis.json
-      - --datadir=/db
-      - --http
-      - --http.addr=0.0.0.0
-      - --http.port=8545
-      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --ws
-      - --ws.addr=0.0.0.0
-      - --ws.port=8546
-      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.port=8551
-      - --authrpc.jwtsecret=/jwt-secret.txt
-      - --nat=none
-      - --disable-discovery
-      - --p2p-secret-key=/p2p-secret.key
-      - --trusted-peers=enode://343bbe0507fd72946e8d57d5b42630dc905aed7e512945eb2dfd99a0d27bb1c7e84ba621c3408242d713a972a581374ea83a4d134651c373c4f2e8425ba99857@ha-el-0:30303,enode://4a1a481e53b57ea351a08d945443cdff9cb7911e9121e8240efa99e4214582c0e383a30706349ce1be88b81d0f6344c401823a6624569e20d26880774279c41c@ha-el-2:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
-    volumes:
-      - "${PWD}/ha-nodekey1:/p2p-secret.key"
-
-  ha-el-2:
-    <<: *reth-service
-    command:
-      - node
-      - --chain=/genesis.json
-      - --datadir=/db
-      - --http
-      - --http.addr=0.0.0.0
-      - --http.port=8545
-      - --http.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --ws
-      - --ws.addr=0.0.0.0
-      - --ws.port=8546
-      - --ws.api=web3,debug,eth,txpool,net,trace,admin,reth
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.port=8551
-      - --authrpc.jwtsecret=/jwt-secret.txt
-      - --nat=none
-      - --disable-discovery
-      - --p2p-secret-key=/p2p-secret.key
-      - --trusted-peers=enode://343bbe0507fd72946e8d57d5b42630dc905aed7e512945eb2dfd99a0d27bb1c7e84ba621c3408242d713a972a581374ea83a4d134651c373c4f2e8425ba99857@ha-el-0:30303,enode://73edbabab8727eba67dd5c2964c610decf28ec73e72d5bc395cc5be3c61ebd76cf72ada700b10926c3d2f9e86d64fafb92c6d02deb48c16439040b7c37f86c2d@ha-el-1:30303,enode://58e698ea2dd8a76e0cb185d13c1faabf223b60c89fef988c8b89496571056d6c2922109537bb291cd87f2ec09a23ac37d59bde2c7a4885d07b7b641cadff2921@morph-el-0:30303,enode://bd755ce0bc8c06b4444b9013e8d1215a02e2b53f39f746f060c292ba2f6877d7b702374f006a49a7b1506bf1bc027b43824859d081283e6bac97c8600cdf3fee@morph-el-1:30303
-    volumes:
-      - "${PWD}/ha-nodekey2:/p2p-secret.key"


### PR DESCRIPTION
## Problem

`make devnet-up-reth` started three containers that immediately died:

```
docker-ha-el-0-1   Exited (2)
docker-ha-el-1-1   Exited (2)
docker-ha-el-2-1   Exited (2)

error: Invalid value '/genesis.json' for --chain <CHAIN_OR_PATH>: No such file or directory
    [possible values: mainnet,hoodi]
```

`docker-compose-reth.yml` carried reth overrides for `ha-el-0/1/2` behind this comment:

> The ha-el-* overrides below only take effect when docker-compose-cluster.yml is passed as well; otherwise these services do not exist and compose ignores them.

That is not how compose merges files. A service named by *any* `-f` file is created, whether or not an earlier file declared it — there is no "override-only" form of a service definition. So in the non-cluster devnet those three `ha-el-*` entries were not overrides of anything; they were full service definitions consisting of only what the reth file happened to specify: an image, an entrypoint, a command with `--chain=/genesis.json`, and a single `ha-nodekeyN` mount. The `/genesis.json` and `/jwt-secret.txt` mounts live in `docker-compose-cluster.yml`, which is not loaded in that mode, so reth had no chain spec to read and exited before doing anything else.

Nothing on the sequencer path breaks as a result — this is why it went unnoticed — but every `devnet-up-reth` leaves three failed containers and three stray datadir volumes behind, and `docker compose up` reports the failures.

## Fix

Move the three `ha-el-*` reth overrides into a new `docker-compose-cluster-reth.yml`, layered only when **both** `--cluster` and reth are requested, in `Makefile` and in `devnet.compose_file_args`. The plain reth devnet now resolves to exactly the geth devnet's service list; the cluster path is unchanged.

Also corrects the same wrong claim where it is repeated in `ops/README.md` and in the two code comments that restate it.

## Verification

`docker compose config --services`, all four combinations:

| mode | services |
| --- | --- |
| geth | `morph-el-0/1`, `node-0/1`, `tx-submitter-0`, `gas-price-oracle`, `layer1-*` |
| reth | identical to geth ✅ (was: **+ `ha-el-0/1/2`**) |
| geth + cluster | above **+ `ha-el-0/1/2`, `ha-node-0/1/2`** |
| reth + cluster | identical to geth + cluster ✅ |

The cluster override still applies — merged `ha-el-*` in `reth + cluster`:

```
image      = ghcr.io/morph-l2/morph-reth:latest
entrypoint = ['/usr/local/bin/morph-reth']
command    contains --chain=/genesis.json
mounts     = /db, /db/geth/nodekey, /db/geth/static-nodes.json,
             /genesis.json, /jwt-secret.txt, /p2p-secret.key
```

`make -n devnet-down` per mode resolves to the intended `-f` lists, and `DEVNET_CLEAN_COMPOSE_FILES` covers the new file so `devnet-clean-build` still reaps cluster leftovers.

`python3 -m unittest discover -s ops/devnet-morph/tests` — 14 tests, all pass. Three are new or reworked:

- `test_reth_compose_leaves_cluster_services_to_the_cluster_reth_file` — regression guard: `docker-compose-reth.yml` must not name `ha-el-*` at all.
- `test_cluster_reth_compose_overrides_the_ha_execution_clients` — the new file carries all three, with the reth image/entrypoint and one key mount each, and does not redefine `morph-el-*`.
- `test_reth_compose_configures_deterministic_peering` — narrowed to the two `morph-el-*` that remain in that file.

End-to-end: `make devnet-clean-build && make devnet-up-reth` on a wiped devnet brings up
`morph-el-0/1`, `node-0/1`, `tx-submitter-0`, `gas-price-oracle` and the three `layer1-*`
containers, with **no `ha-el-*` container created and nothing in `Exited` state** (before this
change the same command left three `Exited (2)`). `morph-el-0` produces blocks normally.

Note `morph-el-1` sits at height 0 for the first ~10 minutes after startup, until
`tx-submitter-0` commits its first batch — `node-1` runs with
`MORPH_NODE_DERIVATION_VERIFY_MODE=layer1`, so L1 derivation is its only source of blocks.
That behaviour is unrelated to this change and is present on `main` too; it is being looked
at separately.


---

## Second commit: exclude `.claude` from the docker build context

Rebuilding `morph-node:latest` while diagnosing an unrelated devnet problem showed the
build context climbing past 20 GB before any build step ran. `.dockerignore` excludes
`.git` (1.1 GB) and `prover/` (1.2 GB), but not `.claude/` — which is **1.0 GB** on any
machine that has used a Claude Code worktree (`.claude/worktrees`):

```
repo total                     6125 MB
  .git                         1094 MB   (excluded)
  prover                       1205 MB   (excluded)
  .claude                      1010 MB   <- not excluded
  contracts/node_modules        718 MB   (excluded)
```

Nothing under `.claude/` is read by a build. One line in `.dockerignore`, next to the
other excluded top-level directories, plus the matching assertion in the existing
`test_root_dockerignore_excludes_generated_build_outputs`. Context after this change
measures 1.74 GB, in line with the ~2.0 GB the repo needs.

(The 20 GB figure itself is not fully explained by this one directory and is not claimed
to be: `ops/docker/.devnet` holds four 4 GB sparse mdbx files — 16 GB logical, ~1 MB on
disk — but a targeted `COPY` probe confirms `.dockerignore` does exclude that path, so
something else contributed. Excluding `.claude/` is correct on its own merits either way.)
