### PR TITLE
build: exclude .claude from the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 prover/
 .git/
+.claude/
 contracts/node_modules/
 gas-oracle/app/target/
 node/build/

--- a/ops/devnet-morph/tests/test_devnet_config.py
+++ b/ops/devnet-morph/tests/test_devnet_config.py
@@ -17,6 +17,10 @@ class DevnetConfigTest(unittest.TestCase):
             "gas-oracle/app/target/",
             "node/build/",
             "ops/docker/.devnet/",
+            # Claude Code keeps its worktrees here; on a machine that has used
+            # one, this is the single largest directory in the repo and every
+            # image build would ship it as build context.
+            ".claude/",
         ):
             self.assertIn(generated_path, dockerignore)
 


### PR DESCRIPTION
## Problem

Rebuilding `morph-node:latest` locally showed the build context climbing past 3 GB before a single build step ran. `.dockerignore` excludes `.git` (1.1 GB) and `prover/` (1.2 GB), but not `.claude/` — which is **1.0 GB** on any machine that has used a Claude Code worktree (`.claude/worktrees`):

```
repo total                     6125 MB
  .git                         1094 MB   (excluded)
  prover                       1205 MB   (excluded)
  .claude                      1010 MB   ← not excluded
  contracts/node_modules        718 MB   (excluded)
```

Nothing under `.claude/` is ever read by a build, so every `docker compose build` shipped it: ~3.0 GB of context transferred where ~2.0 GB is required.

## Fix

One line in `.dockerignore`, next to the other excluded top-level directories, plus the matching assertion in the existing `test_root_dockerignore_excludes_generated_build_outputs`.

`python3 -m unittest discover -s ops/devnet-morph/tests` — 12 tests, all pass.